### PR TITLE
Add `triggerFlow` to the library ([#3](https://github.com/DCtheTall/twilly/issues/3))

### DIFF
--- a/examples/quickstart.js
+++ b/examples/quickstart.js
@@ -1,6 +1,8 @@
 const bp = require('body-parser');
 const express = require('express');
 
+require('dotenv').load();
+
 const { twilly, Flow, Reply } = require('../dist');
 
 const app = express();

--- a/examples/quickstart.js
+++ b/examples/quickstart.js
@@ -1,8 +1,6 @@
 const bp = require('body-parser');
 const express = require('express');
 
-require('dotenv').load();
-
 const { twilly, Flow, Reply } = require('../dist');
 
 const app = express();
@@ -25,6 +23,10 @@ app.use('/twilly', twilly({
   authToken: TWILIO_AUTH_TOKEN,
   messagingServiceSid: TWILIO_MESSAGE_SERVICE_ID,
   root,
+  onCatchError(ctx, userCtx, err) {
+    /* It is generally good practice to always include this hook. */
+    console.log(err);
+  },
 }));
 
 require('http')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twilly",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7668,9 +7668,9 @@
       "optional": true
     },
     "twilio": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.33.0.tgz",
-      "integrity": "sha512-Cgq6AIw+pBXNrnmnUbfAcUGqFUVi/HbmDVhXiWuePNJ23n/AS86adOnunso//+mHTJdBnOaQOopZNLvvx0qALA==",
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.33.2.tgz",
+      "integrity": "sha512-aKmZKL5dP79Xt1pkEhHyTZQj9xRRaWBKPrOKa30aXYnm9mVxZ5FPVawipq+Sho7c6JYpmyQK1FNsTJhV78dtrQ==",
       "requires": {
         "@types/express": "^4.16.1",
         "deprecate": "1.0.0",
@@ -7682,13 +7682,6 @@
         "rootpath": "0.1.2",
         "scmp": "2.0.0",
         "xmlbuilder": "9.0.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1",
     "lodash": "^4.17.13",
-    "twilio": "^3.33.0"
+    "twilio": "^3.33.2"
   },
   "devDependencies": {
     "@types/es6-promise": "^3.3.0",

--- a/src/Actions/Question.ts
+++ b/src/Actions/Question.ts
@@ -254,15 +254,15 @@ export default class Question extends Action {
   }
 
   public async [QuestionEvaluate](
-    req: TwilioWebhookRequest,
+    messageBody: string,
     state: SmsCookie,
   ) {
     if (!state.question.isAnswering) return;
     if (
       (this.type === Question.Types.Text)
-        && (await this.validateAnswer(req.body.Body))
+        && (await this.validateAnswer(messageBody))
     ) {
-      this.setAnswer(req.body.Body);
+      this.setAnswer(messageBody);
       return;
     }
 
@@ -270,7 +270,7 @@ export default class Question extends Action {
       const choices =
         await Promise.all(
           this.choices.map(
-            (validate: AnswerValidator) => validate(req.body.Body)));
+            (validate: AnswerValidator) => validate(messageBody)));
       const validChoices =
         choices.map((_, i) => i)
                 .filter(i => choices[i]);

--- a/src/Flows/Controller.ts
+++ b/src/Flows/Controller.ts
@@ -116,7 +116,7 @@ export default class FlowController {
     return this.schema.get(state.flow);
   }
 
-  private async resolveActionFromState(
+  public async resolveActionFromState(
     messageBody: string,
     state: SmsCookie,
     userCtx: any,
@@ -146,19 +146,6 @@ export default class FlowController {
     action[ActionSetName](currFlow[FlowSelectActionName](key));
 
     return action;
-  }
-
-  public async resolveActionFromRequest(
-    req: TwilioWebhookRequest,
-    state: SmsCookie,
-    userCtx: any,
-  ): Promise<Action> {
-    return this.resolveActionFromState(req.body.Body, state, userCtx);
-  }
-
-  // TODO: test this method.
-  public async resolveActionFromFlowTrigger(state: SmsCookie, userCtx: any) {
-    return this.resolveActionFromState(null, state, userCtx);
   }
 
   public resolveNextStateFromAction(

--- a/src/Flows/Controller.ts
+++ b/src/Flows/Controller.ts
@@ -156,6 +156,11 @@ export default class FlowController {
     return this.resolveActionFromState(req.body.Body, state, userCtx);
   }
 
+  // TODO: test this method.
+  public async resolveActionFromFlowTrigger(state: SmsCookie, userCtx: any) {
+    return this.resolveActionFromState(null, state, userCtx);
+  }
+
   public resolveNextStateFromAction(
     req: TwilioWebhookRequest,
     state: SmsCookie,

--- a/src/Flows/Controller.ts
+++ b/src/Flows/Controller.ts
@@ -27,10 +27,7 @@ import {
   createSmsCookie,
   FlowContext,
 } from '../SmsCookie';
-import {
-  TwilioWebhookRequest,
-  getMockTwilioWebhookRequest,
-} from '../twllio';
+import { TwilioWebhookRequest } from '../twllio';
 import { compose, deepCopy } from '../util';
 
 
@@ -38,7 +35,7 @@ type SmsCookieUpdate = (state?: SmsCookie) => SmsCookie;
 
 export function pipeSmsCookieUpdates(...funcs: SmsCookieUpdate[]): SmsCookieUpdate {
   return (
-    cookie: SmsCookie = createSmsCookie(getMockTwilioWebhookRequest()),
+    cookie: SmsCookie = createSmsCookie(),
   ): SmsCookie => compose(...funcs)(cookie);
 }
 

--- a/src/Flows/Controller.ts
+++ b/src/Flows/Controller.ts
@@ -16,6 +16,7 @@ import {
   QuestionEvaluate,
 } from '../Actions';
 import {
+  FlowContext,
   InteractionContext,
   SmsCookie,
   completeInteraction,
@@ -24,20 +25,10 @@ import {
   startQuestion,
   updateContext,
   addQuestionAttempt,
-  createSmsCookie,
-  FlowContext,
+  pipeSmsCookieUpdates,
 } from '../SmsCookie';
 import { TwilioWebhookRequest } from '../twllio';
 import { compose, deepCopy } from '../util';
-
-
-type SmsCookieUpdate = (state?: SmsCookie) => SmsCookie;
-
-export function pipeSmsCookieUpdates(...funcs: SmsCookieUpdate[]): SmsCookieUpdate {
-  return (
-    cookie: SmsCookie = createSmsCookie(),
-  ): SmsCookie => compose(...funcs)(cookie);
-}
 
 
 export type ExitKeywordTest =

--- a/src/SmsCookie/index.ts
+++ b/src/SmsCookie/index.ts
@@ -1,4 +1,4 @@
-import { uniqueString, compose } from '../util';
+import { compose, uniqueString } from '../util';
 import {
   Action,
   ActionContext,
@@ -8,9 +8,6 @@ import {
   ActionGetContext,
 } from '../Actions';
 import { Flow, FlowActionNames } from '../Flows';
-import {
-  TwilioWebhookRequest,
-} from '../twllio';
 
 
 export type FlowContext = { [index: string]: ActionContext };
@@ -145,4 +142,12 @@ export function updateContext(
       },
     ],
   };
+}
+
+type SmsCookieUpdate = (state?: SmsCookie) => SmsCookie;
+
+export function pipeSmsCookieUpdates(...funcs: SmsCookieUpdate[]): SmsCookieUpdate {
+  return (
+    cookie: SmsCookie = createSmsCookie(),
+  ): SmsCookie => compose(...funcs)(cookie);
 }

--- a/src/SmsCookie/index.ts
+++ b/src/SmsCookie/index.ts
@@ -44,11 +44,11 @@ export function completeInteraction(state: SmsCookie) {
   return { ...state, isComplete: true };
 }
 
-
-export function createSmsCookie(): SmsCookie {
+// TODO: test when flow name is supplied.
+export function createSmsCookie(flowName: string = null): SmsCookie {
   return {
     createdAt: new Date(),
-    flow: null,
+    flow: flowName,
     flowContext: {},
     flowKey: 0,
     interactionComplete: false,

--- a/src/SmsCookie/index.ts
+++ b/src/SmsCookie/index.ts
@@ -18,7 +18,6 @@ export type InteractionContext = ActionContext[];
 
 export interface SmsCookie {
   createdAt: Date;
-  from: string;
   flow: string;
   flowContext: FlowContext;
   flowKey: string | number;
@@ -49,13 +48,12 @@ export function completeInteraction(state: SmsCookie) {
 }
 
 
-export function createSmsCookie(req: TwilioWebhookRequest): SmsCookie {
+export function createSmsCookie(): SmsCookie {
   return {
     createdAt: new Date(),
     flow: null,
     flowContext: {},
     flowKey: 0,
-    from: req.body.From,
     interactionComplete: false,
     interactionContext: [],
     interactionId: uniqueString(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,12 +209,10 @@ export function twilly({
   if (twillyLocals.has(name)) {
     console.warn(`There already exists a Twilly instance with the name: ${name}`);
   }
-  const locals: LocalTwillyVariables = {hooks: {}};
-
+  const locals: LocalTwillyVariables = {
+    hooks: { getUserContext, onCatchError, onMessage },
+  };
   twillyLocals.set(name, locals);
-  locals.hooks.getUserContext = getUserContext;
-  locals.hooks.onCatchError = onCatchError;
-  locals.hooks.onMessage = onMessage;
 
   if (!cookieKey) {
     cookieKey = getSha256Hash(accountSid, accountSid).slice(0, 16);

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,8 +81,7 @@ async function handleIncomingSmsWebhook(
   try {
     state = locals.twilioController.getSmsCookieFromRequest(req);
     userCtx = await locals.hooks.getUserContext(req.body.From); // will throw any errors not caught in promise
-
-    let action = await locals.flowController.resolveActionFromRequest(req, state, userCtx);
+    let action = await locals.flowController.resolveActionFromState(req.body.Body, state, userCtx);
 
     if (locals.hooks.onMessage) {
       try {
@@ -110,7 +109,7 @@ async function handleIncomingSmsWebhook(
           && !(<Question>action).isComplete
         )
       ) break;
-      action = await locals.flowController.resolveActionFromRequest(req, state, userCtx);
+      action = await locals.flowController.resolveActionFromState(req.body.Body, state, userCtx);
       if (action === null) break;
     }
 
@@ -258,8 +257,7 @@ export async function triggerFlow(to: string, flowName: string, {
 
   try {
     userCtx = await locals.hooks.getUserContext(to);
-
-    let action = await locals.flowController.resolveActionFromFlowTrigger(state, userCtx);
+    let action = await locals.flowController.resolveActionFromState(null, state, userCtx);
 
     while (action !== null) {
       await locals.twilioController.handleAction(to, action);

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,8 +143,7 @@ async function handleIncomingSmsWebhook(
         state = updateContext(
           state,
           locals.flowController.getCurrentFlow(state),
-          result,
-        );
+          result);
       }
       if (locals.flowController.onInteractionEnd !== null) {
         await locals.flowController.onInteractionEnd(state.interactionContext, userCtx);
@@ -254,7 +253,7 @@ export async function triggerFlow(to: string, flowName: string, {
 } = defaultTriggerFlowParameters) {
   const locals = twillyLocals.get(twillyName);
 
-  let state: SmsCookie = createSmsCookie();
+  let state: SmsCookie = createSmsCookie(flowName);
   let userCtx: any = null;
 
   try {
@@ -264,6 +263,10 @@ export async function triggerFlow(to: string, flowName: string, {
 
     while (action !== null) {
       await locals.twilioController.handleAction(to, action);
+      await new Promise(
+        resolve => setTimeout(resolve, DELAY));
+
+      // state = await locals.flowController.reso(state, action);
     }
   } catch (err) {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   defaultTestForExit,
 } from './Flows';
 import {
+  Action,
   Message,
   Question,
   Reply,
@@ -99,8 +100,7 @@ async function handleIncomingSmsWebhook(
       await locals.twilioController.handleAction(req.body.From, action);
       await new Promise(
         resolve => setTimeout(resolve, DELAY)); // for preserving message order
-
-      state = await locals.flowController.resolveNextStateFromAction(req, state, action);
+      state = await locals.flowController.resolveNextStateFromAction(req.body.Body, state, action);
 
       if (
         (state.isComplete)

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ interface LocalTwillyVariables {
 
 const twillyLocals = new Map<string, LocalTwillyVariables>();
 
+
 async function handleIncomingSmsWebhook(
   locals: LocalTwillyVariables,
   req: TwilioWebhookRequest,
@@ -169,7 +170,7 @@ interface TwillyParameters extends TwilioControllerArgs {
   testForExit?: ExitKeywordTest;
 }
 
-const defaultParameters = <TwillyParameters>{
+const defaultTwillyParameters = <TwillyParameters>{
   cookieKey: null,
   cookieSecret: null,
   getUserContext: <UserContextGetter>(() => null),
@@ -188,23 +189,23 @@ export function twilly({
   messagingServiceSid,
 
   root,
-  schema = defaultParameters.schema,
+  schema = defaultTwillyParameters.schema,
 
-  cookieKey = defaultParameters.cookieKey,
-  cookieSecret = defaultParameters.cookieSecret,
+  cookieKey = defaultTwillyParameters.cookieKey,
+  cookieSecret = defaultTwillyParameters.cookieSecret,
 
-  getUserContext = defaultParameters.getUserContext,
+  getUserContext = defaultTwillyParameters.getUserContext,
 
-  onCatchError = defaultParameters.onCatchError,
-  onInteractionEnd = defaultParameters.onInteractionEnd,
-  onMessage = defaultParameters.onMessage,
+  onCatchError = defaultTwillyParameters.onCatchError,
+  onInteractionEnd = defaultTwillyParameters.onInteractionEnd,
+  onMessage = defaultTwillyParameters.onMessage,
 
-  sendOnExit = defaultParameters.sendOnExit,
-  testForExit = defaultParameters.testForExit,
+  sendOnExit = defaultTwillyParameters.sendOnExit,
+  testForExit = defaultTwillyParameters.testForExit,
 
-  name = defaultParameters.name,
+  name = defaultTwillyParameters.name,
 }: TwillyParameters): Router {
-  if (name !== defaultParameters.name && twillyLocals.has(name)) {
+  if (name !== defaultTwillyParameters.name && twillyLocals.has(name)) {
     console.warn(`There already exists a Twilly instance with the name: ${name}`);
   }
   const locals: LocalTwillyVariables = { hooks: {} };
@@ -238,4 +239,20 @@ export function twilly({
   router.post(
     ROUTE_REGEXP, handleIncomingSmsWebhook.bind(null, locals));
   return router;
+}
+
+
+interface TriggerFlowParameters {
+  name: string;
+}
+
+const defaultTriggerFlowParameters = {
+  name: DEFAULT_TWILLY_NAME,
+};
+
+function triggerFlow(flowName, {
+  name = defaultTriggerFlowParameters.name,
+} = defaultTriggerFlowParameters) {
+  const locals = twillyLocals.get(name);
+  // TODO refactor FlowController to support this.
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,6 @@ async function handleIncomingSmsWebhook(
         )
       ) break;
       action = await locals.flowController.resolveActionFromState(req.body.Body, state, userCtx);
-      if (action === null) break;
     }
 
     if (state.isComplete) {
@@ -247,24 +246,25 @@ const defaultTriggerFlowParameters = {
   twillyName: DEFAULT_TWILLY_NAME,
 };
 
-export async function triggerFlow(to: string, flowName: string, {
+export async function triggerFlow(to: string, flow: Flow, {
   twillyName = defaultTriggerFlowParameters.twillyName,
 } = defaultTriggerFlowParameters) {
   const locals = twillyLocals.get(twillyName);
 
-  let state: SmsCookie = createSmsCookie(flowName);
-  let userCtx: any = null;
+  // TODO: refactor to have it just evaluate this Flow in the function. Disallow Exit, Trigger, and Question actions.
+  // let state: SmsCookie = createSmsCookie(flow.name);
+  // let userCtx: any = null;
 
-  try {
-    userCtx = await locals.hooks.getUserContext(to);
-    let action = await locals.flowController.resolveActionFromState(null, state, userCtx);
+  // try {
+  //   userCtx = await locals.hooks.getUserContext(to);
+  //   let action = await locals.flowController.resolveActionFromState(null, state, userCtx);
 
-    while (action !== null) {
-      await locals.twilioController.handleAction(to, action);
-      await new Promise(
-        resolve => setTimeout(resolve, DELAY));
+  //   while (action !== null) {
+  //     await locals.twilioController.handleAction(to, action);
+  //     await new Promise(
+  //       resolve => setTimeout(resolve, DELAY));
 
-      // state = await locals.flowController.reso(state, action);
-    }
-  } catch (err) {}
+  //     // state = await locals.flowController.reso(state, action);
+  //   }
+  // } catch (err) {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 import { Router, Response, RequestHandler } from 'express';
 
-import { AnyFunc, getSha256Hash } from './util';
+import {
+  assertFlow,
+  assertFn,
+  assertString,
+  getSha256Hash,
+} from './util';
 import {
   TwilioController,
   TwilioControllerArgs,
@@ -229,12 +234,6 @@ const defaultTriggerFlowParameters = {
   messagingServiceSid: null,
 } as TriggerFlowParameters;
 
-const checkFn = (name: string, fn: AnyFunc): void => {
-  if (!fn || typeof fn !== 'function') {
-    throw new TypeError(`You must provide a function to the ${name} parameter`);
-  }
-};
-
 // TODO: Attempt to write function for executing shared code between triggerFlow and handleSmsWebhook.
 export async function triggerFlow(to: string, flow: Flow, {
   getUserContext = defaultTriggerFlowParameters.getUserContext,
@@ -244,8 +243,15 @@ export async function triggerFlow(to: string, flow: Flow, {
   authToken = defaultTriggerFlowParameters.authToken,
   messagingServiceSid = defaultTriggerFlowParameters.messagingServiceSid,
 } = defaultTriggerFlowParameters) {
-  checkFn('getUserContext', getUserContext);
-  checkFn('onCatchError', onCatchError);
+  assertString('first', to);
+  assertFlow('second', flow);
+
+  assertFn('getUserContext', getUserContext);
+  assertFn('onCatchError', onCatchError);
+
+  assertString('accountSid', accountSid);
+  assertString('authToken', authToken);
+  assertString('messagingServiceSid', messagingServiceSid);
 
   let state: SmsCookie = createSmsCookie();
   let userCtx: any = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
 import {
   InteractionContext,
   SmsCookie,
+  createSmsCookie,
   updateContext,
 } from './SmsCookie';
 
@@ -43,7 +44,7 @@ const cookieParser =
 const DEFAULT_EXIT_TEXT = 'Goodbye.';
 const DELAY = process.env.NODE_ENV === 'test' ? 10 : 1000;
 const ROUTE_REGEXP = /^\/?$/i;
-const DEFAULT_TWILLY_NAME = '__DEFAULT_TWILLY_NAME__';
+const DEFAULT_TWILLY_NAME = '__$$_DEFAULT_TWILLY_$$__';
 
 
 type OnMessageHook =
@@ -205,10 +206,10 @@ export function twilly({
 
   name = defaultTwillyParameters.name,
 }: TwillyParameters): Router {
-  if (name !== defaultTwillyParameters.name && twillyLocals.has(name)) {
+  if (twillyLocals.has(name)) {
     console.warn(`There already exists a Twilly instance with the name: ${name}`);
   }
-  const locals: LocalTwillyVariables = { hooks: {} };
+  const locals: LocalTwillyVariables = {hooks: {}};
 
   twillyLocals.set(name, locals);
   locals.hooks.getUserContext = getUserContext;
@@ -243,16 +244,20 @@ export function twilly({
 
 
 interface TriggerFlowParameters {
-  name: string;
+  twillyName?: string;
 }
 
 const defaultTriggerFlowParameters = {
-  name: DEFAULT_TWILLY_NAME,
+  twillyName: DEFAULT_TWILLY_NAME,
 };
 
-function triggerFlow(flowName, {
-  name = defaultTriggerFlowParameters.name,
+export function triggerFlow(flowName, {
+  twillyName = defaultTriggerFlowParameters.twillyName,
 } = defaultTriggerFlowParameters) {
-  const locals = twillyLocals.get(name);
-  // TODO refactor FlowController to support this.
+  const locals = twillyLocals.get(twillyName);
+
+  let state: SmsCookie = null;
+  let userCtx: any = null;
+
+
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ async function handleIncomingSmsWebhook(
     }
 
     while (action !== null) {
-      await locals.twilioController.handleAction(req, action);
+      await locals.twilioController.handleAction(req.body.From, action);
       await new Promise(
         resolve => setTimeout(resolve, DELAY)); // for preserving message order
 
@@ -139,7 +139,7 @@ async function handleIncomingSmsWebhook(
 
     try {
       if (result instanceof Reply) {
-        await locals.twilioController.handleAction(req, result);
+        await locals.twilioController.handleAction(req.body.From, result);
         state = updateContext(
           state,
           locals.flowController.getCurrentFlow(state),
@@ -259,5 +259,11 @@ export async function triggerFlow(to: string, flowName: string, {
 
   try {
     userCtx = await locals.hooks.getUserContext(to);
+
+    let action = await locals.flowController.resolveActionFromFlowTrigger(state, userCtx);
+
+    while (action !== null) {
+      await locals.twilioController.handleAction(to, action);
+    }
   } catch (err) {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,7 @@ const checkFn = (name: string, fn: AnyFunc): void => {
   }
 };
 
+// TODO: Attempt to write function for executing shared code between triggerFlow and handleSmsWebhook.
 export async function triggerFlow(to: string, flow: Flow, {
   getUserContext = defaultTriggerFlowParameters.getUserContext,
   onCatchError = defaultTriggerFlowParameters.onCatchError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,6 +261,7 @@ export async function triggerFlow(to: string, flow: Flow, {
     authToken,
     cookieKey: null,
     messagingServiceSid,
+    sendOnExit: null,
   });
 
   try {
@@ -268,8 +269,8 @@ export async function triggerFlow(to: string, flow: Flow, {
     let action = await fc.resolveActionFromState(null, state, userCtx);
 
     while (action !== null) {
-      if (!(action instanceof Message)) {
-        throw new Error('You can only use Message actions in triggerFlow');
+      if (![Message, Reply].some(Ctor => action instanceof Ctor)) {
+        throw new Error('You can only use Reply or Message actions in triggerFlow');
       }
       await tc.handleAction(to, action);
       await new Promise(

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
 import {
   InteractionContext,
   SmsCookie,
+  createSmsCookie,
   updateContext,
 } from './SmsCookie';
 
@@ -81,7 +82,7 @@ async function handleIncomingSmsWebhook(
     state = locals.twilioController.getSmsCookieFromRequest(req);
     userCtx = await locals.hooks.getUserContext(req.body.From); // will throw any errors not caught in promise
 
-    let action = await locals.flowController.resolveActionFromState(req, state, userCtx);
+    let action = await locals.flowController.resolveActionFromRequest(req, state, userCtx);
 
     if (locals.hooks.onMessage) {
       try {
@@ -109,7 +110,7 @@ async function handleIncomingSmsWebhook(
           && !(<Question>action).isComplete
         )
       ) break;
-      action = await locals.flowController.resolveActionFromState(req, state, userCtx);
+      action = await locals.flowController.resolveActionFromRequest(req, state, userCtx);
       if (action === null) break;
     }
 
@@ -248,13 +249,15 @@ const defaultTriggerFlowParameters = {
   twillyName: DEFAULT_TWILLY_NAME,
 };
 
-export function triggerFlow(flowName, {
+export async function triggerFlow(to: string, flowName: string, {
   twillyName = defaultTriggerFlowParameters.twillyName,
 } = defaultTriggerFlowParameters) {
   const locals = twillyLocals.get(twillyName);
 
-  let state: SmsCookie = null;
+  let state: SmsCookie = createSmsCookie();
   let userCtx: any = null;
 
-
+  try {
+    userCtx = await locals.hooks.getUserContext(to);
+  } catch (err) {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Router, Response, RequestHandler } from 'express';
 
-import { getSha256Hash } from './util';
+import { getSha256Hash, warn } from './util';
 import {
   TwilioController,
   TwilioControllerArgs,
@@ -22,7 +22,6 @@ import {
 import {
   InteractionContext,
   SmsCookie,
-  createSmsCookie,
   updateContext,
 } from './SmsCookie';
 
@@ -207,7 +206,7 @@ export function twilly({
   name = defaultTwillyParameters.name,
 }: TwillyParameters): Router {
   if (twillyLocals.has(name)) {
-    console.warn(`There already exists a Twilly instance with the name: ${name}`);
+    warn(`There already exists a Twilly instance with the name: ${name}`);
   }
   const locals: LocalTwillyVariables = {
     hooks: { getUserContext, onCatchError, onMessage },

--- a/src/twllio/Controller.ts
+++ b/src/twllio/Controller.ts
@@ -102,7 +102,7 @@ export default class TwilioController {
   }
 
   public async handleAction(
-    req: TwilioWebhookRequest,
+    phoneNumber: string,
     action: Action,
   ): Promise<void> {
     let sid: string;
@@ -111,17 +111,15 @@ export default class TwilioController {
     switch (action.constructor) {
       case Exit:
         sid = <string>(await this.sendSmsMessage(
-          req.body.From,
-          this.sendOnExit,
-        ));
+          phoneNumber,
+          this.sendOnExit));
         action[ActionSetMessageSid](<string>sid);
         return;
 
       case Message:
         sids = <string[]>(await this.sendSmsMessage(
           (<Message>action).to,
-          (<Message>action).body,
-        ));
+          (<Message>action).body));
         action[ActionSetMessageSids](sids);
         return;
 
@@ -132,31 +130,27 @@ export default class TwilioController {
           if (question.isAnswered) return;
           if (question.isFailed) {
             sids.push(<string>(await this.sendSmsMessage(
-              req.body.From,
-              question.failedAnswerResponse,
-            )));
+              phoneNumber,
+              question.failedAnswerResponse)));
             action[ActionSetMessageSids](sids);
             return;
           }
           if (question.shouldSendInvalidRes) {
             sids.push(<string>(await this.sendSmsMessage(
-              req.body.From,
-              question.invalidAnswerResponse,
-            )));
+              phoneNumber,
+              question.invalidAnswerResponse)));
           }
           sids.push(<string>(await this.sendSmsMessage(
-            req.body.From,
-            question.body,
-          )));
+            phoneNumber,
+            question.body)));
           action[ActionSetMessageSids](sids);
         })();
         return;
 
       case Reply:
         sid = <string>(await this.sendSmsMessage(
-          req.body.From,
-          (<Reply>action).body,
-        ));
+          phoneNumber,
+          (<Reply>action).body));
         action[ActionSetMessageSid](sid);
         return;
 

--- a/src/twllio/Controller.ts
+++ b/src/twllio/Controller.ts
@@ -98,7 +98,7 @@ export default class TwilioController {
   }
 
   public getSmsCookieFromRequest(req: TwilioWebhookRequest): SmsCookie {
-    return req.cookies[this.cookieKey] || createSmsCookie(req);
+    return req.cookies[this.cookieKey] || createSmsCookie();
   }
 
   public async handleAction(

--- a/src/twllio/Controller.ts
+++ b/src/twllio/Controller.ts
@@ -22,6 +22,7 @@ type TwilioFactory = (accountSid: string, authToken: string) => TwilioClient;
 
 const twilio = <TwilioFactory>require('twilio');
 
+const KeysNotSetInTriggerFlow = new Set(['cookieKey', 'sendOnExit']);
 
 export interface TwilioControllerArgs {
   accountSid: string;
@@ -39,6 +40,9 @@ export default class TwilioController {
 
   static typeCheckArguments(args: TwilioControllerArgs) {
     Object.keys(args).map((option: string) => {
+      if (KeysNotSetInTriggerFlow.has(option) && args[option] === null) {
+        return;
+      }
       if (!TwilioController.isValidString(args[option])) {
         throw new TypeError(
           `${option} twilly option must be a non-empty string`);

--- a/src/twllio/TwilioWebhookRequest.ts
+++ b/src/twllio/TwilioWebhookRequest.ts
@@ -14,9 +14,7 @@ export interface RequestHeader {
 }
 
 
-export const XmlContentTypeHeader = <RequestHeader>{
-  'Content-Type': 'text/xml',
-};
+export const XmlContentTypeHeader = <RequestHeader>{'Content-Type': 'text/xml'};
 
 
 export interface TwilioWebhookRequestBody {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -3,7 +3,7 @@ import Flow from '../Flows/Flow';
 import Reply from '../Actions/Reply';
 
 
-export function getSha256Hash(secret: string, key: string): string {
+export function getSHA256Hash(secret: string, key: string): string {
   const hmac = createHmac('sha256', secret);
   hmac.update(key);
   return hmac.digest('hex');
@@ -69,8 +69,11 @@ function assertInstanceof<T>(paramName: string, ctor: any, obj: any) {
   }
 }
 
-export const assertFn = (paramName: string, fn: AnyFunc) => assertType(paramName, 'function', fn);
+export const assertParameterIsFunction =
+    (paramName: string, fn: AnyFunc) => assertType(paramName, 'function', fn);
 
-export const assertString = (paramNane: string, str: string) => assertType(paramNane, 'string', str);
+export const assertParameterIsString =
+    (paramNane: string, str: string) => assertType(paramNane, 'string', str);
 
-export const assertFlow = (paramName: string, flow: Flow) => assertInstanceof(paramName, Flow, flow);
+export const assertParameterIsFlow =
+    (paramName: string, flow: Flow) => assertInstanceof(paramName, Flow, flow);

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -23,7 +23,7 @@ export function randomFlow(): Flow {
 }
 
 
-type AnyFunc =
+export type AnyFunc =
   (...args: any[]) => any;
 
 export function compose(...fns: AnyFunc[]): AnyFunc {
@@ -56,8 +56,4 @@ export function deepCopy<T>(obj: T): T {
       }
     });
   return result;
-}
-
-export function warn(...args: any[]): void {
-  console.warn(args);
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -23,8 +23,7 @@ export function randomFlow(): Flow {
 }
 
 
-export type AnyFunc =
-  (...args: any[]) => any;
+type AnyFunc = (...args: any[]) => any;
 
 export function compose(...fns: AnyFunc[]): AnyFunc {
   return fns.reduce(
@@ -57,3 +56,21 @@ export function deepCopy<T>(obj: T): T {
     });
   return result;
 }
+
+function assertType<T>(paramName: string, typename: string, t: T) {
+  if (!t || typeof t !== typename) {
+    throw new TypeError(`You must use ${typename} for the ${paramName} parameter`);
+  }
+}
+
+function assertInstanceof<T>(paramName: string, ctor: any, obj: any) {
+  if (! obj || !(obj instanceof ctor)) {
+    throw new TypeError(`You must provide an instanceof ${ctor.name} for the ${paramName} parameter`);
+  }
+}
+
+export const assertFn = (paramName: string, fn: AnyFunc) => assertType(paramName, 'function', fn);
+
+export const assertString = (paramNane: string, str: string) => assertType(paramNane, 'string', str);
+
+export const assertFlow = (paramName: string, flow: Flow) => assertInstanceof(paramName, Flow, flow);

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -38,7 +38,7 @@ export function randInt(): number {
 
 
 /**
- * Create a static deep copy of a serealizable object
+ * Create a static deep copy of a JSON serealizable object.
  */
 export function deepCopy<T>(obj: T): T {
   const result = <T>{};
@@ -56,4 +56,8 @@ export function deepCopy<T>(obj: T): T {
       }
     });
   return result;
+}
+
+export function warn(...args: any[]): void {
+  console.warn(args);
 }

--- a/tests/Actions/Question.spec.ts
+++ b/tests/Actions/Question.spec.ts
@@ -283,7 +283,7 @@ test('Question evaluating valid text answer', async () => {
   const answer = uniqueString();
   const q = new Question(uniqueString(), { validateAnswer: ans => ans === answer });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   await q[QuestionEvaluate](reqMock, stateMock);
@@ -304,7 +304,7 @@ test('Question evaluating invalid text answer with retry left', async () => {
   });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const errorHandlerStub = jest.fn();
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   await q[QuestionEvaluate](reqMock, stateMock);
@@ -324,7 +324,7 @@ test('Question evaluating invalid text answer without retry left', async () => {
     validateAnswer: ans => Promise.resolve(ans !== answer),
   });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   stateMock.question.attempts = [uniqueString()];
@@ -349,7 +349,7 @@ test('Question evaluating valid multiple choice answer', async () => {
     ],
   });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   await q[QuestionEvaluate](reqMock, stateMock);
@@ -374,7 +374,7 @@ test('Question validates multiple choices selected with retry left', async () =>
   });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const errorHandlerStub = jest.fn();
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   await q[QuestionEvaluate](reqMock, stateMock);
@@ -398,7 +398,7 @@ test('Question validates multiple choices selected without retry left', async ()
     ],
   });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   stateMock.question.attempts = [uniqueString()];
@@ -423,7 +423,7 @@ test('Question evaluating invalid multiple choice answer with retry left', async
     ],
   });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   await q[QuestionEvaluate](reqMock, stateMock);
@@ -447,7 +447,7 @@ test('Question evaluating invalid multiple choice answer without retry left', as
     ],
   });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   stateMock.question.attempts = [uniqueString()];
@@ -469,7 +469,7 @@ test('Question evaluating with more maxRetries than 1', async () => {
     maxRetries: 3,
   });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   stateMock.question.attempts = [uniqueString(), uniqueString()];
@@ -492,7 +492,7 @@ test('Question should not evaluate when not answering the question yet', async (
     maxRetries: 3,
   });
   const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const stateMock = createSmsCookie(reqMock);
+  const stateMock = createSmsCookie();
 
   await q[QuestionEvaluate](reqMock, stateMock);
 

--- a/tests/Actions/Question.spec.ts
+++ b/tests/Actions/Question.spec.ts
@@ -282,11 +282,10 @@ test(
 test('Question evaluating valid text answer', async () => {
   const answer = uniqueString();
   const q = new Question(uniqueString(), { validateAnswer: ans => ans === answer });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(q.isAnswered).toBe(true);
   expect(q.isFailed).toBe(false);
@@ -302,12 +301,10 @@ test('Question evaluating invalid text answer with retry left', async () => {
   const q = new Question(uniqueString(), {
     validateAnswer: ans => Promise.resolve(ans !== answer),
   });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const errorHandlerStub = jest.fn();
   const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(q.isFailed).toBe(false);
   expect(q.isAnswered).toBe(false);
@@ -323,12 +320,11 @@ test('Question evaluating invalid text answer without retry left', async () => {
   const q = new Question(uniqueString(), {
     validateAnswer: ans => Promise.resolve(ans !== answer),
   });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   stateMock.question.attempts = [uniqueString()];
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(q.isAnswered).toBe(false);
   expect(q.isFailed).toBe(true);
@@ -348,11 +344,10 @@ test('Question evaluating valid multiple choice answer', async () => {
       ans => ans === answer,
     ],
   });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(q.isAnswered).toBe(true);
   expect(q.isFailed).toBe(false);
@@ -372,12 +367,10 @@ test('Question validates multiple choices selected with retry left', async () =>
       ans => ans === answer,
     ],
   });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
-  const errorHandlerStub = jest.fn();
   const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(q.isFailed).toBe(false);
   expect(q.isAnswered).toBe(false);
@@ -397,12 +390,11 @@ test('Question validates multiple choices selected without retry left', async ()
       ans => ans === answer,
     ],
   });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   stateMock.question.attempts = [uniqueString()];
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(q.isAnswered).toBe(false);
   expect(q.isFailed).toBe(true);
@@ -422,11 +414,10 @@ test('Question evaluating invalid multiple choice answer with retry left', async
       ans => Promise.resolve(ans !== answer),
     ],
   });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(q.isFailed).toBe(false);
   expect(q.isAnswered).toBe(false);
@@ -446,12 +437,11 @@ test('Question evaluating invalid multiple choice answer without retry left', as
       ans => Promise.resolve(ans !== answer),
     ],
   });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   stateMock.question.attempts = [uniqueString()];
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(q.isFailed).toBe(true);
   expect(q.isAnswered).toBe(false);
@@ -468,12 +458,11 @@ test('Question evaluating with more maxRetries than 1', async () => {
     validateAnswer: () => false,
     maxRetries: 3,
   });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const stateMock = createSmsCookie();
 
   stateMock.question.isAnswering = true;
   stateMock.question.attempts = [uniqueString(), uniqueString()];
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(q.isFailed).toBe(false);
   expect(q.isAnswered).toBe(false);
@@ -491,10 +480,9 @@ test('Question should not evaluate when not answering the question yet', async (
     validateAnswer,
     maxRetries: 3,
   });
-  const reqMock = getMockTwilioWebhookRequest({ body: answer });
   const stateMock = createSmsCookie();
 
-  await q[QuestionEvaluate](reqMock, stateMock);
+  await q[QuestionEvaluate](answer, stateMock);
 
   expect(validateAnswer).toBeCalledTimes(0);
 });

--- a/tests/Flows/Controller.spec.ts
+++ b/tests/Flows/Controller.spec.ts
@@ -198,7 +198,7 @@ test('FlowController should take an onInteractionEnd option', () => {
 
 
 test(
-  'FlowController resolveActionFromState should return null if interaction is complete',
+  'FlowController resolveActionFromRequest should return null if interaction is complete',
   async () => {
     const fc = new FlowController(randomFlow());
     const req = getMockTwilioWebhookRequest();
@@ -214,7 +214,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should test if the user wants to exit the interaction',
+  'FlowController resolveActionFromRequest should test if the user wants to exit the interaction',
   async () => {
     const testForExit = jest.fn();
     const flow = randomFlow();
@@ -236,7 +236,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should return an Exit action '
+  'FlowController resolveActionFromRequest should return an Exit action '
   + 'if the testForExit test resolves true',
   async () => {
     const testForExit = jest.fn();
@@ -258,7 +258,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should default to the first action '
+  'FlowController resolveActionFromRequest should default to the first action '
   + 'of the root if no Flow has been started',
   async () => {
     const replyName = uniqueString();
@@ -282,7 +282,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should resolve an action in the root flow '
+  'FlowController resolveActionFromRequest should resolve an action in the root flow '
   + 'if the current flow in the SMS cookie is the root',
   async () => {
     const replyName = uniqueString();
@@ -307,7 +307,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should resolve the current flow from the schema',
+  'FlowController resolveActionFromRequest should resolve the current flow from the schema',
   async () => {
     const replyName = uniqueString();
     const flowReply = new Reply(replyName);
@@ -339,7 +339,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should throw an error '
+  'FlowController resolveActionFromRequest should throw an error '
   + 'if the state specifies a flow not in the schema',
   async () => {
     const root = randomFlow();
@@ -365,7 +365,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should determine '
+  'FlowController resolveActionFromRequest should determine '
   + 'which action in the root Flow to resolve',
   async () => {
     const replyName = uniqueString();
@@ -395,7 +395,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should determine '
+  'FlowController resolveActionFromRequest should determine '
   + 'which action to use in the Flow schema',
   async () => {
     const replyName = uniqueString();
@@ -429,7 +429,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should return null '
+  'FlowController resolveActionFromRequest should return null '
   + 'if there is no action left to take',
   async () => {
     const root = randomFlow();
@@ -453,7 +453,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should evaluate the state of a Question action',
+  'FlowController resolveActionFromRequest should evaluate the state of a Question action',
   async () => {
     const root = randomFlow();
     const q = new Question(uniqueString());
@@ -480,7 +480,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromState should return null '
+  'FlowController resolveActionFromRequest should return null '
   + 'if the resolver returns any object that is not an Action',
   async () => {
     const executeTest = async (obj: any) => {

--- a/tests/Flows/Controller.spec.ts
+++ b/tests/Flows/Controller.spec.ts
@@ -18,9 +18,7 @@ import { uniqueString, randomFlow } from '../../src/util';
 import { getMockTwilioWebhookRequest } from '../../src/twllio';
 import * as SmsCookieModule from '../../src/SmsCookie';
 
-
-const createSmsCookie = SmsCookieModule.createSmsCookie;
-
+const { createSmsCookie } = SmsCookieModule;
 
 test('FlowController base case: root flow with one action', () => {
   let caught: Error;
@@ -205,7 +203,7 @@ test(
     const fc = new FlowController(randomFlow());
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
 
     state.isComplete = true;
     const result = await fc.resolveActionFromState(req, state, user);
@@ -225,7 +223,7 @@ test(
     });
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
 
     testForExit.mockResolvedValue(false);
     const result = await fc.resolveActionFromState(req, state, user);
@@ -248,7 +246,7 @@ test(
     });
     const req = getMockTwilioWebhookRequest({ body: uniqueString() });
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
 
     testForExit.mockResolvedValue(true);
     const result = <Exit>(await fc.resolveActionFromState(req, state, user));
@@ -270,7 +268,7 @@ test(
       new Flow().addAction(replyName, resolver));
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
 
     resolver.mockResolvedValue(rootReply);
     const result = await fc.resolveActionFromState(req, state, user);
@@ -294,7 +292,7 @@ test(
     const fc = new FlowController(root);
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
 
     state.flow = root.name;
     resolver.mockResolvedValue(rootReply);
@@ -326,7 +324,7 @@ test(
     const fc = new FlowController(root, schema);
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
 
     state.flow = `${flowParentName}.${flowName}`;
     resolver.mockResolvedValue(flowReply);
@@ -347,7 +345,7 @@ test(
     const root = randomFlow();
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const fc = new FlowController(root);
 
     let caught: Error;
@@ -382,7 +380,7 @@ test(
     const fc = new FlowController(root);
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
 
     state.flowKey = 2;
     resolver.mockResolvedValue(reply);
@@ -415,7 +413,7 @@ test(
     }));
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
 
     state.flow = flow.name;
     state.flowKey = 1;
@@ -438,7 +436,7 @@ test(
     const fc = new FlowController(root);
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
 
     state.flowKey = 1;
     let result = await fc.resolveActionFromState(req, state, user);
@@ -467,7 +465,7 @@ test(
 
     const req = getMockTwilioWebhookRequest();
     const user = {};
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const fc = new FlowController(root);
 
     resolver.mockResolvedValue(q);
@@ -493,7 +491,7 @@ test(
 
       const req = getMockTwilioWebhookRequest();
       const user = {};
-      const state = createSmsCookie(req);
+      const state = createSmsCookie();
       const fc = new FlowController(root);
 
       resolver.mockResolvedValue(obj);
@@ -520,7 +518,7 @@ test(
     const executeTest = (action: any) => {
       const fc = new FlowController(randomFlow());
       const req = getMockTwilioWebhookRequest();
-      const state = createSmsCookie(req);
+      const state = createSmsCookie();
       const newState = { ...state };
 
       const completeInteraction = jest.spyOn(SmsCookieModule, 'completeInteraction');
@@ -551,7 +549,7 @@ test(
   () => {
     const root = randomFlow();
     const req = getMockTwilioWebhookRequest();
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const exit = new Exit(uniqueString());
     const fc = new FlowController(root);
     const updatedState = { ...state };
@@ -581,7 +579,7 @@ test(
   () => {
     const root = randomFlow();
     const req = getMockTwilioWebhookRequest();
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const stateWithAttempt = { ...state };
     const updatedState = { ...state };
     const newState = { ...state };
@@ -620,7 +618,7 @@ test(
   () => {
     const root = randomFlow();
     const req = getMockTwilioWebhookRequest();
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const stateWithAttempt = { ...state };
     const updatedState = { ...state };
     const newState = { ...state };
@@ -659,7 +657,7 @@ test(
   () => {
     const root = randomFlow();
     const req = getMockTwilioWebhookRequest();
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const stateWithAttempt = { ...state };
     const updatedState = { ...state };
     const newState = { ...state };
@@ -698,7 +696,7 @@ test(
   () => {
     const root = randomFlow();
     const req = getMockTwilioWebhookRequest();
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const stateWithAttempt = { ...state };
     const newState = { ...state };
     const q = new Question(uniqueString());
@@ -727,7 +725,7 @@ test(
 test('FlowController resolveNextStateFromAction should start an unstarted Question', () => {
   const root = randomFlow();
   const req = getMockTwilioWebhookRequest();
-  const state = createSmsCookie(req);
+  const state = createSmsCookie();
   const stateStartedQuestion = { ...state };
   const newState = { ...state };
   const q = new Question(uniqueString());
@@ -756,7 +754,7 @@ test(
     + 'if there is no defined schema',
   () => {
     const req = getMockTwilioWebhookRequest();
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const trigger = new Trigger(uniqueString());
     const fc = new FlowController(randomFlow());
 
@@ -779,7 +777,7 @@ test(
     + 'if the Flow the Trigger starts is not in the schema',
   () => {
     const req = getMockTwilioWebhookRequest();
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const trigger = new Trigger(uniqueString());
     const fc = new FlowController(randomFlow(), new FlowSchema({
       [uniqueString()]: randomFlow(),
@@ -801,7 +799,7 @@ test(
 
 test('FlowController resolveNextStateFromAction should handle Trigger actions', () => {
   const req = getMockTwilioWebhookRequest();
-  const state = createSmsCookie(req);
+  const state = createSmsCookie();
   const flow1Name = uniqueString();
   const flow2Name = uniqueString();
   const flow1 = randomFlow();
@@ -838,7 +836,7 @@ test(
     + 'and update the context by default',
   () => {
     const req = getMockTwilioWebhookRequest();
-    const state = createSmsCookie(req);
+    const state = createSmsCookie();
     const root = randomFlow();
     const fc = new FlowController(root);
     const updatedState = { ...state };

--- a/tests/Flows/Controller.spec.ts
+++ b/tests/Flows/Controller.spec.ts
@@ -206,7 +206,7 @@ test(
     const state = createSmsCookie();
 
     state.isComplete = true;
-    const result = await fc.resolveActionFromState(req, state, user);
+    const result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(result).toBe(null);
   },
@@ -226,7 +226,7 @@ test(
     const state = createSmsCookie();
 
     testForExit.mockResolvedValue(false);
-    const result = await fc.resolveActionFromState(req, state, user);
+    const result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(testForExit).toBeCalledTimes(1);
     expect(testForExit).toBeCalledWith(req.body.Body);
@@ -249,7 +249,7 @@ test(
     const state = createSmsCookie();
 
     testForExit.mockResolvedValue(true);
-    const result = <Exit>(await fc.resolveActionFromState(req, state, user));
+    const result = <Exit>(await fc.resolveActionFromRequest(req, state, user));
 
     expect(result instanceof Exit).toBeTruthy();
     expect(result[GetContext]()).toEqual({ messageBody: req.body.Body });
@@ -271,7 +271,7 @@ test(
     const state = createSmsCookie();
 
     resolver.mockResolvedValue(rootReply);
-    const result = await fc.resolveActionFromState(req, state, user);
+    const result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -296,7 +296,7 @@ test(
 
     state.flow = root.name;
     resolver.mockResolvedValue(rootReply);
-    const result = await fc.resolveActionFromState(req, state, user);
+    const result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -328,7 +328,7 @@ test(
 
     state.flow = `${flowParentName}.${flowName}`;
     resolver.mockResolvedValue(flowReply);
-    const result = await fc.resolveActionFromState(req, state, user);
+    const result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -352,7 +352,7 @@ test(
 
     try {
       state.flow = uniqueString();
-      await fc.resolveActionFromState(req, state, user);
+      await fc.resolveActionFromRequest(req, state, user);
     } catch (err) {
       caught = err;
     }
@@ -384,7 +384,7 @@ test(
 
     state.flowKey = 2;
     resolver.mockResolvedValue(reply);
-    const result = await fc.resolveActionFromState(req, state, user);
+    const result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -418,7 +418,7 @@ test(
     state.flow = flow.name;
     state.flowKey = 1;
     resolver.mockResolvedValue(reply);
-    const result = await fc.resolveActionFromState(req, state, user);
+    const result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -439,13 +439,13 @@ test(
     const state = createSmsCookie();
 
     state.flowKey = 1;
-    let result = await fc.resolveActionFromState(req, state, user);
+    let result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(result).toBe(null);
 
     root.addAction(uniqueString(), () => new Reply(uniqueString()));
     state.flowKey = 2;
-    result = await fc.resolveActionFromState(req, state, user);
+    result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(result).toBe(null);
   },
@@ -470,11 +470,11 @@ test(
 
     resolver.mockResolvedValue(q);
     state.flowKey = 1;
-    const result = await fc.resolveActionFromState(req, state, user);
+    const result = await fc.resolveActionFromRequest(req, state, user);
 
     expect(result).toBe(q);
     expect(q[QuestionEvaluate]).toBeCalledTimes(1);
-    expect(q[QuestionEvaluate]).toBeCalledWith(req, state);
+    expect(q[QuestionEvaluate]).toBeCalledWith(req.body.Body, state);
   },
 );
 
@@ -496,7 +496,7 @@ test(
 
       resolver.mockResolvedValue(obj);
       state.flowKey = 1;
-      const result = await fc.resolveActionFromState(req, state, user);
+      const result = await fc.resolveActionFromRequest(req, state, user);
 
       expect(result).toBe(null);
     };

--- a/tests/Flows/Controller.spec.ts
+++ b/tests/Flows/Controller.spec.ts
@@ -198,7 +198,7 @@ test('FlowController should take an onInteractionEnd option', () => {
 
 
 test(
-  'FlowController resolveActionFromRequest should return null if interaction is complete',
+  'FlowController resolveActionFromState should return null if interaction is complete',
   async () => {
     const fc = new FlowController(randomFlow());
     const req = getMockTwilioWebhookRequest();
@@ -206,7 +206,7 @@ test(
     const state = createSmsCookie();
 
     state.isComplete = true;
-    const result = await fc.resolveActionFromRequest(req, state, user);
+    const result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(result).toBe(null);
   },
@@ -214,7 +214,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should test if the user wants to exit the interaction',
+  'FlowController resolveActionFromState should test if the user wants to exit the interaction',
   async () => {
     const testForExit = jest.fn();
     const flow = randomFlow();
@@ -226,7 +226,7 @@ test(
     const state = createSmsCookie();
 
     testForExit.mockResolvedValue(false);
-    const result = await fc.resolveActionFromRequest(req, state, user);
+    const result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(testForExit).toBeCalledTimes(1);
     expect(testForExit).toBeCalledWith(req.body.Body);
@@ -236,7 +236,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should return an Exit action '
+  'FlowController resolveActionFromState should return an Exit action '
   + 'if the testForExit test resolves true',
   async () => {
     const testForExit = jest.fn();
@@ -249,7 +249,7 @@ test(
     const state = createSmsCookie();
 
     testForExit.mockResolvedValue(true);
-    const result = <Exit>(await fc.resolveActionFromRequest(req, state, user));
+    const result = <Exit>(await fc.resolveActionFromState(req.body.Body, state, user));
 
     expect(result instanceof Exit).toBeTruthy();
     expect(result[GetContext]()).toEqual({ messageBody: req.body.Body });
@@ -258,7 +258,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should default to the first action '
+  'FlowController resolveActionFromState should default to the first action '
   + 'of the root if no Flow has been started',
   async () => {
     const replyName = uniqueString();
@@ -271,7 +271,7 @@ test(
     const state = createSmsCookie();
 
     resolver.mockResolvedValue(rootReply);
-    const result = await fc.resolveActionFromRequest(req, state, user);
+    const result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -282,7 +282,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should resolve an action in the root flow '
+  'FlowController resolveActionFromState should resolve an action in the root flow '
   + 'if the current flow in the SMS cookie is the root',
   async () => {
     const replyName = uniqueString();
@@ -296,7 +296,7 @@ test(
 
     state.flow = root.name;
     resolver.mockResolvedValue(rootReply);
-    const result = await fc.resolveActionFromRequest(req, state, user);
+    const result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -307,7 +307,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should resolve the current flow from the schema',
+  'FlowController resolveActionFromState should resolve the current flow from the schema',
   async () => {
     const replyName = uniqueString();
     const flowReply = new Reply(replyName);
@@ -328,7 +328,7 @@ test(
 
     state.flow = `${flowParentName}.${flowName}`;
     resolver.mockResolvedValue(flowReply);
-    const result = await fc.resolveActionFromRequest(req, state, user);
+    const result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -339,7 +339,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should throw an error '
+  'FlowController resolveActionFromState should throw an error '
   + 'if the state specifies a flow not in the schema',
   async () => {
     const root = randomFlow();
@@ -352,7 +352,7 @@ test(
 
     try {
       state.flow = uniqueString();
-      await fc.resolveActionFromRequest(req, state, user);
+      await fc.resolveActionFromState(req.body.Body, state, user);
     } catch (err) {
       caught = err;
     }
@@ -365,7 +365,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should determine '
+  'FlowController resolveActionFromState should determine '
   + 'which action in the root Flow to resolve',
   async () => {
     const replyName = uniqueString();
@@ -384,7 +384,7 @@ test(
 
     state.flowKey = 2;
     resolver.mockResolvedValue(reply);
-    const result = await fc.resolveActionFromRequest(req, state, user);
+    const result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -395,7 +395,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should determine '
+  'FlowController resolveActionFromState should determine '
   + 'which action to use in the Flow schema',
   async () => {
     const replyName = uniqueString();
@@ -418,7 +418,7 @@ test(
     state.flow = flow.name;
     state.flowKey = 1;
     resolver.mockResolvedValue(reply);
-    const result = await fc.resolveActionFromRequest(req, state, user);
+    const result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(resolver).toBeCalledTimes(1);
     expect(resolver).toBeCalledWith(state.flowContext, user);
@@ -429,7 +429,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should return null '
+  'FlowController resolveActionFromState should return null '
   + 'if there is no action left to take',
   async () => {
     const root = randomFlow();
@@ -439,13 +439,13 @@ test(
     const state = createSmsCookie();
 
     state.flowKey = 1;
-    let result = await fc.resolveActionFromRequest(req, state, user);
+    let result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(result).toBe(null);
 
     root.addAction(uniqueString(), () => new Reply(uniqueString()));
     state.flowKey = 2;
-    result = await fc.resolveActionFromRequest(req, state, user);
+    result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(result).toBe(null);
   },
@@ -453,7 +453,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should evaluate the state of a Question action',
+  'FlowController resolveActionFromState should evaluate the state of a Question action',
   async () => {
     const root = randomFlow();
     const q = new Question(uniqueString());
@@ -470,7 +470,7 @@ test(
 
     resolver.mockResolvedValue(q);
     state.flowKey = 1;
-    const result = await fc.resolveActionFromRequest(req, state, user);
+    const result = await fc.resolveActionFromState(req.body.Body, state, user);
 
     expect(result).toBe(q);
     expect(q[QuestionEvaluate]).toBeCalledTimes(1);
@@ -480,7 +480,7 @@ test(
 
 
 test(
-  'FlowController resolveActionFromRequest should return null '
+  'FlowController resolveActionFromState should return null '
   + 'if the resolver returns any object that is not an Action',
   async () => {
     const executeTest = async (obj: any) => {
@@ -496,7 +496,7 @@ test(
 
       resolver.mockResolvedValue(obj);
       state.flowKey = 1;
-      const result = await fc.resolveActionFromRequest(req, state, user);
+      const result = await fc.resolveActionFromState(req.body.Body, state, user);
 
       expect(result).toBe(null);
     };

--- a/tests/Flows/Controller.spec.ts
+++ b/tests/Flows/Controller.spec.ts
@@ -517,14 +517,14 @@ test(
   () => {
     const executeTest = (action: any) => {
       const fc = new FlowController(randomFlow());
-      const req = getMockTwilioWebhookRequest();
+      const body = uniqueString();
       const state = createSmsCookie();
       const newState = { ...state };
 
       const completeInteraction = jest.spyOn(SmsCookieModule, 'completeInteraction');
 
       completeInteraction.mockReturnValue(newState);
-      const result = fc.resolveNextStateFromAction(req, state, action);
+      const result = fc.resolveNextStateFromAction(body, state, action);
 
       expect(completeInteraction).toBeCalledTimes(1);
       expect(completeInteraction).toBeCalledWith(state);
@@ -548,7 +548,7 @@ test(
     + 'if it receives an Exit action',
   () => {
     const root = randomFlow();
-    const req = getMockTwilioWebhookRequest();
+    const body = uniqueString();
     const state = createSmsCookie();
     const exit = new Exit(uniqueString());
     const fc = new FlowController(root);
@@ -560,7 +560,7 @@ test(
 
     updateContext.mockReturnValue(updatedState);
     completeInteraction.mockReturnValue(newState);
-    const result = fc.resolveNextStateFromAction(req, state, exit);
+    const result = fc.resolveNextStateFromAction(body, state, exit);
 
     expect(updateContext).toBeCalledTimes(1);
     expect(updateContext).toBeCalledWith(state, root, exit);
@@ -578,7 +578,7 @@ test(
   'FlowController resolveNextStateFromAction should handle an answered Question',
   () => {
     const root = randomFlow();
-    const req = getMockTwilioWebhookRequest();
+    const body = uniqueString();
     const state = createSmsCookie();
     const stateWithAttempt = { ...state };
     const updatedState = { ...state };
@@ -595,10 +595,10 @@ test(
     addQuestionAttempt.mockReturnValue(stateWithAttempt);
     updateContext.mockReturnValue(updatedState);
     incrementFlowAction.mockReturnValue(newState);
-    const result = fc.resolveNextStateFromAction(req, state, q);
+    const result = fc.resolveNextStateFromAction(body, state, q);
 
     expect(addQuestionAttempt).toBeCalledTimes(1);
-    expect(addQuestionAttempt).toBeCalledWith(state, req.body.Body);
+    expect(addQuestionAttempt).toBeCalledWith(state, body);
     expect(updateContext).toBeCalledTimes(1);
     expect(updateContext).toBeCalledWith(stateWithAttempt, root, q);
     expect(incrementFlowAction).toBeCalledTimes(1);
@@ -617,7 +617,7 @@ test(
     + 'when it should continue on fail',
   () => {
     const root = randomFlow();
-    const req = getMockTwilioWebhookRequest();
+    const body = uniqueString();
     const state = createSmsCookie();
     const stateWithAttempt = { ...state };
     const updatedState = { ...state };
@@ -634,10 +634,10 @@ test(
     addQuestionAttempt.mockReturnValue(stateWithAttempt);
     updateContext.mockReturnValue(updatedState);
     incrementFlowAction.mockReturnValue(newState);
-    const result = fc.resolveNextStateFromAction(req, state, q);
+    const result = fc.resolveNextStateFromAction(body, state, q);
 
     expect(addQuestionAttempt).toBeCalledTimes(1);
-    expect(addQuestionAttempt).toBeCalledWith(state, req.body.Body);
+    expect(addQuestionAttempt).toBeCalledWith(state, body);
     expect(updateContext).toBeCalledTimes(1);
     expect(updateContext).toBeCalledWith(stateWithAttempt, root, q);
     expect(incrementFlowAction).toBeCalledTimes(1);
@@ -656,7 +656,7 @@ test(
   + 'when it should not continue on fail',
   () => {
     const root = randomFlow();
-    const req = getMockTwilioWebhookRequest();
+    const body = uniqueString();
     const state = createSmsCookie();
     const stateWithAttempt = { ...state };
     const updatedState = { ...state };
@@ -673,10 +673,10 @@ test(
     addQuestionAttempt.mockReturnValue(stateWithAttempt);
     updateContext.mockReturnValue(updatedState);
     completeInteraction.mockReturnValue(newState);
-    const result = fc.resolveNextStateFromAction(req, state, q);
+    const result = fc.resolveNextStateFromAction(body, state, q);
 
     expect(addQuestionAttempt).toBeCalledTimes(1);
-    expect(addQuestionAttempt).toBeCalledWith(state, req.body.Body);
+    expect(addQuestionAttempt).toBeCalledWith(state, body);
     expect(updateContext).toBeCalledTimes(1);
     expect(updateContext).toBeCalledWith(stateWithAttempt, root, q);
     expect(completeInteraction).toBeCalledTimes(1);
@@ -695,7 +695,7 @@ test(
     + 'while a Question is being answered',
   () => {
     const root = randomFlow();
-    const req = getMockTwilioWebhookRequest();
+    const body = uniqueString();
     const state = createSmsCookie();
     const stateWithAttempt = { ...state };
     const newState = { ...state };
@@ -708,10 +708,10 @@ test(
     state.question.isAnswering = true;
     addQuestionAttempt.mockReturnValue(stateWithAttempt);
     updateContext.mockReturnValue(newState);
-    const result = fc.resolveNextStateFromAction(req, state, q);
+    const result = fc.resolveNextStateFromAction(body, state, q);
 
     expect(addQuestionAttempt).toBeCalledTimes(1);
-    expect(addQuestionAttempt).toBeCalledWith(state, req.body.Body);
+    expect(addQuestionAttempt).toBeCalledWith(state, body);
     expect(updateContext).toBeCalledTimes(1);
     expect(updateContext).toBeCalledWith(stateWithAttempt, root, q);
     expect(result).toBe(newState);
@@ -724,7 +724,7 @@ test(
 
 test('FlowController resolveNextStateFromAction should start an unstarted Question', () => {
   const root = randomFlow();
-  const req = getMockTwilioWebhookRequest();
+  const body = uniqueString();
   const state = createSmsCookie();
   const stateStartedQuestion = { ...state };
   const newState = { ...state };
@@ -736,7 +736,7 @@ test('FlowController resolveNextStateFromAction should start an unstarted Questi
 
   startQuestion.mockReturnValue(stateStartedQuestion);
   updateContext.mockReturnValue(newState);
-  const result = fc.resolveNextStateFromAction(req, state, q);
+  const result = fc.resolveNextStateFromAction(body, state, q);
 
   expect(startQuestion).toBeCalledTimes(1);
   expect(startQuestion).toBeCalledWith(state);
@@ -753,7 +753,7 @@ test(
   'FlowController resolveNextStateFromAction Trigger should throw a TypeError '
     + 'if there is no defined schema',
   () => {
-    const req = getMockTwilioWebhookRequest();
+    const body = uniqueString();
     const state = createSmsCookie();
     const trigger = new Trigger(uniqueString());
     const fc = new FlowController(randomFlow());
@@ -761,7 +761,7 @@ test(
     let caught: Error;
 
     try {
-      fc.resolveNextStateFromAction(req, state, trigger);
+      fc.resolveNextStateFromAction(body, state, trigger);
     } catch (err) {
       caught = err;
     }
@@ -776,7 +776,7 @@ test(
   'FlowController resolveNextStateFromAction Trigger should throw a TypeError '
     + 'if the Flow the Trigger starts is not in the schema',
   () => {
-    const req = getMockTwilioWebhookRequest();
+    const body = uniqueString();
     const state = createSmsCookie();
     const trigger = new Trigger(uniqueString());
     const fc = new FlowController(randomFlow(), new FlowSchema({
@@ -786,7 +786,7 @@ test(
     let caught: Error;
 
     try {
-      fc.resolveNextStateFromAction(req, state, trigger);
+      fc.resolveNextStateFromAction(body, state, trigger);
     } catch (err) {
       caught = err;
     }
@@ -798,7 +798,7 @@ test(
 
 
 test('FlowController resolveNextStateFromAction should handle Trigger actions', () => {
-  const req = getMockTwilioWebhookRequest();
+  const body = uniqueString();
   const state = createSmsCookie();
   const flow1Name = uniqueString();
   const flow2Name = uniqueString();
@@ -818,7 +818,7 @@ test('FlowController resolveNextStateFromAction should handle Trigger actions', 
   state.flow = flow1Name;
   updateContext.mockReturnValue(updatedState);
   handleTrigger.mockReturnValue(newState);
-  const result = fc.resolveNextStateFromAction(req, state, trigger);
+  const result = fc.resolveNextStateFromAction(body, state, trigger);
 
   expect(updateContext).toBeCalledTimes(1);
   expect(updateContext).toBeCalledWith(state, flow1, trigger);
@@ -835,7 +835,7 @@ test(
   'FlowController resolveNextStateFromAction should increment the flow action '
     + 'and update the context by default',
   () => {
-    const req = getMockTwilioWebhookRequest();
+    const body = uniqueString();
     const state = createSmsCookie();
     const root = randomFlow();
     const fc = new FlowController(root);
@@ -848,7 +848,7 @@ test(
 
     updateContext.mockReturnValue(updatedState);
     incrementFlowAction.mockReturnValue(newState);
-    const result = fc.resolveNextStateFromAction(req, state, reply);
+    const result = fc.resolveNextStateFromAction(body, state, reply);
 
     expect(updateContext).toBeCalledTimes(1);
     expect(updateContext).toBeCalledWith(state, root, reply);

--- a/tests/SmsCookie/SmsCookie.spec.ts
+++ b/tests/SmsCookie/SmsCookie.spec.ts
@@ -201,16 +201,11 @@ test('SmsCookie updateContext: Interaction with mutliple actions', () => {
   const { createdAt: c1, ...rest1 } = reply1[ActionGetContext]();
   const { createdAt: c2, ...rest2 } = reply2[ActionGetContext]();
 
-  const update1 =
-    (state: SmsCookieModule.SmsCookie) =>
-      SmsCookieModule.updateContext(state, flow, reply1);
-  const update2 =
-    (state: SmsCookieModule.SmsCookie) =>
-      SmsCookieModule.updateContext(state, flow, reply2);
-
   const cookie = pipeSmsCookieUpdates(
-    update1,
-    update2,
+    (state: SmsCookieModule.SmsCookie) =>
+      SmsCookieModule.updateContext(state, flow, reply1),
+    (state: SmsCookieModule.SmsCookie) =>
+      SmsCookieModule.updateContext(state, flow, reply2),
   )();
 
   expect(cookie.flowContext[reply1.name]).toMatchObject(rest1);
@@ -243,21 +238,14 @@ test('SmsCookie updateContext: Interaction with multiple Flows', () => {
   const { createdAt: c2, ...r2Rest } = reply2[ActionGetContext]();
   const { createdAt: c3, ...tRest } = trigger[ActionGetContext]();
 
-  const update1 =
+  const cookie = pipeSmsCookieUpdates(
     (state: SmsCookieModule.SmsCookie) =>
-      SmsCookieModule.updateContext(state, flow1, reply1);
-  const update2 =
+      SmsCookieModule.updateContext(state, flow1, reply1),
     (state: SmsCookieModule.SmsCookie) =>
       SmsCookieModule.handleTrigger(
-        SmsCookieModule.updateContext(state, flow1, trigger), trigger);
-  const update3 =
+        SmsCookieModule.updateContext(state, flow1, trigger), trigger),
     (state: SmsCookieModule.SmsCookie) =>
-      SmsCookieModule.updateContext(state, flow2, reply2);
-
-  const cookie = pipeSmsCookieUpdates(
-    update1,
-    update2,
-    update3,
+      SmsCookieModule.updateContext(state, flow2, reply2),
   )();
 
   expect(cookie.flowContext).not.toHaveProperty(reply1.name);

--- a/tests/SmsCookie/SmsCookie.spec.ts
+++ b/tests/SmsCookie/SmsCookie.spec.ts
@@ -20,11 +20,10 @@ import {
 
 
 test('SmsCookie addQuestionAttempt', () => {
-  const req = getMockTwilioWebhookRequest();
   const attempt1 = uniqueString();
   const attempt2 = uniqueString();
 
-  let cookie = SmsCookieModule.createSmsCookie(req);
+  let cookie = SmsCookieModule.createSmsCookie();
 
   cookie.question.attempts = [attempt1];
   cookie = SmsCookieModule.addQuestionAttempt(cookie, attempt2);
@@ -33,9 +32,7 @@ test('SmsCookie addQuestionAttempt', () => {
 
 
 test('SmsCookie completeInteraction', () => {
-  const req = getMockTwilioWebhookRequest();
-
-  let cookie = SmsCookieModule.createSmsCookie(req);
+  let cookie = SmsCookieModule.createSmsCookie();
 
   cookie = SmsCookieModule.completeInteraction(cookie);
   expect(cookie.isComplete).toBe(true);
@@ -43,14 +40,12 @@ test('SmsCookie completeInteraction', () => {
 
 
 test('SmsCookie createSmsCookie', () => {
-  const req = getMockTwilioWebhookRequest();
-  const cookie = SmsCookieModule.createSmsCookie(req);
+  const cookie = SmsCookieModule.createSmsCookie();
 
   expect(cookie).toMatchObject({
     flow: null,
     flowContext: {},
     flowKey: 0,
-    from: req.body.From,
     interactionComplete: false,
     interactionContext: [],
     isComplete: false,
@@ -65,10 +60,9 @@ test('SmsCookie createSmsCookie', () => {
 
 
 test('SmsCookie handleTrigger', () => {
-  const req = getMockTwilioWebhookRequest();
   const trigger = new Trigger(uniqueString());
 
-  let cookie = SmsCookieModule.createSmsCookie(req);
+  let cookie = SmsCookieModule.createSmsCookie();
 
   cookie = SmsCookieModule.handleTrigger(cookie, trigger);
   expect(cookie).toMatchObject({
@@ -80,10 +74,9 @@ test('SmsCookie handleTrigger', () => {
 
 
 test('SmsCookie incrementFlowAction flow not yet complete', () => {
-  const req = getMockTwilioWebhookRequest();
   const flow = new Flow();
 
-  let cookie = SmsCookieModule.createSmsCookie(req);
+  let cookie = SmsCookieModule.createSmsCookie();
 
   cookie.flowKey = 1;
   flow.addActions([
@@ -100,10 +93,9 @@ test('SmsCookie incrementFlowAction flow not yet complete', () => {
 
 
 test('SmsCookie incrementFlowAction flow complete', () => {
-  const req = getMockTwilioWebhookRequest();
   const flow = new Flow();
 
-  let cookie = SmsCookieModule.createSmsCookie(req);
+  let cookie = SmsCookieModule.createSmsCookie();
 
   cookie.flowKey = 2;
   flow.addActions([
@@ -120,9 +112,7 @@ test('SmsCookie incrementFlowAction flow complete', () => {
 
 
 test('SmsCookie startQuestion', () => {
-  const req = getMockTwilioWebhookRequest();
-
-  let cookie = SmsCookieModule.createSmsCookie(req);
+  let cookie = SmsCookieModule.createSmsCookie();
 
   cookie = SmsCookieModule.startQuestion(cookie);
   expect(cookie).toMatchObject({
@@ -158,7 +148,7 @@ test(
 
     try {
       SmsCookieModule.updateContext(
-        SmsCookieModule.createSmsCookie(getMockTwilioWebhookRequest()), flow, reply);
+        SmsCookieModule.createSmsCookie(), flow, reply);
     } catch (err) {
       caught = err;
     }
@@ -184,7 +174,7 @@ test('SmsCookie updateContext base case: An interaction with a single reply', ()
 
   const update = state => SmsCookieModule.updateContext(state, flow, reply);
   const cookie = update(
-    SmsCookieModule.createSmsCookie(getMockTwilioWebhookRequest()));
+    SmsCookieModule.createSmsCookie());
 
   expect(cookie.flowContext[reply.name].createdAt.constructor).toBe(Date);
   expect(cookie.flowContext[reply.name]).toMatchObject(rest);
@@ -304,7 +294,7 @@ test('SmsCookie updateContext: recording Question sids', () => {
   let { createdAt, ...rest } = q[ActionGetContext]();
 
   let cookie = SmsCookieModule.updateContext(
-    SmsCookieModule.createSmsCookie(getMockTwilioWebhookRequest()), flow, q);
+    SmsCookieModule.createSmsCookie(), flow, q);
 
   expect(cookie.flowContext[q.name]).toMatchObject(rest);
   expect(cookie.flowContext[q.name].createdAt.constructor).toBe(Date);

--- a/tests/SmsCookie/SmsCookie.spec.ts
+++ b/tests/SmsCookie/SmsCookie.spec.ts
@@ -1,5 +1,4 @@
 import * as SmsCookieModule from '../../src/SmsCookie';
-import { getMockTwilioWebhookRequest } from '../../src/twllio';
 import {
   randomFlow,
   uniqueString,
@@ -15,9 +14,9 @@ import {
 import {
   Flow,
   FlowSetName,
-  pipeSmsCookieUpdates,
 } from '../../src/Flows';
 
+const { pipeSmsCookieUpdates } = SmsCookieModule;
 
 test('SmsCookie addQuestionAttempt', () => {
   const attempt1 = uniqueString();

--- a/tests/twilio/Controller.spec.ts
+++ b/tests/twilio/Controller.spec.ts
@@ -112,7 +112,7 @@ test('TwilioController clearSmsCookie test', () => {
 test('TwilioController getSmsCookeFromRequest with no cookie set', () => {
   const req = getMockTwilioWebhookRequest();
   const tc = new TwilioController(args);
-  const { createdAt, interactionId, ...rest } = createSmsCookie(req);
+  const {createdAt, interactionId, ...rest} = createSmsCookie();
   const cookie = tc.getSmsCookieFromRequest(req);
   expect(cookie).toMatchObject(rest);
   expect(cookie.createdAt.constructor).toBe(Date);
@@ -123,7 +123,7 @@ test('TwilioController getSmsCookeFromRequest with no cookie set', () => {
 test('TwilioController getSmsCookeFromRequest with cookie set', () => {
   const req = getMockTwilioWebhookRequest();
   const tc = new TwilioController(args);
-  const prevCookie = createSmsCookie(req);
+  const prevCookie = createSmsCookie();
 
   req.cookies[args.cookieKey] = prevCookie;
   const cookie = tc.getSmsCookieFromRequest(req);
@@ -378,7 +378,7 @@ test('TwilioController sendSmsResponse test', () => {
 test('TwilioController setSmsCookie test', () => {
   const res = <any>{ cookie: jest.fn() };
   const tc = new TwilioController(args);
-  const cookie = createSmsCookie(getMockTwilioWebhookRequest());
+  const cookie = createSmsCookie();
 
   tc.setSmsCookie(res, cookie);
 

--- a/tests/twilio/Controller.spec.ts
+++ b/tests/twilio/Controller.spec.ts
@@ -140,7 +140,7 @@ test('TwilioController handleAction receives Exit action', async () => {
 
   exit[ActionSetMessageSid] = jest.fn();
   twilioMessagesCreate.mockResolvedValue({ sid });
-  await tc.handleAction(req, exit);
+  await tc.handleAction(req.body.From, exit);
 
   expect(twilioMessagesCreate).toBeCalledTimes(1);
   expect(twilioMessagesCreate).toBeCalledWith({
@@ -161,7 +161,7 @@ test('TwilioController handleAction receives Message action with single recipien
 
   msg[ActionSetMessageSids] = jest.fn();
   twilioMessagesCreate.mockResolvedValue({ sid });
-  await tc.handleAction(req, msg);
+  await tc.handleAction(req.body.From, msg);
 
   expect(twilioMessagesCreate).toBeCalledTimes(1);
   expect(twilioMessagesCreate).toBeCalledWith({
@@ -193,7 +193,7 @@ test('TwilioController handleAction receives Message action with multiple recipi
     twilioMessagesCreate.mockResolvedValueOnce({ sid }));
   msg[ActionSetMessageSids] = setSids = jest.fn();
 
-  await tc.handleAction(req, msg);
+  await tc.handleAction(req.body.From, msg);
 
   expect(twilioMessagesCreate).toBeCalledTimes(3);
   [...Array(3)].map(
@@ -216,7 +216,7 @@ test('TwilioController handleAction receives Question that has been answered', a
   q[ActionSetMessageSids] = setSids = jest.fn();
   q[QuestionSetIsAnswered]();
 
-  await tc.handleAction(req, q);
+  await tc.handleAction(req.body.From, q);
 
   expect(twilioMessagesCreate).toBeCalledTimes(0);
   expect(setSids).toBeCalledTimes(0);
@@ -233,7 +233,7 @@ test('TwilioController handleAction receives Question that has been failed', asy
   twilioMessagesCreate.mockResolvedValue({ sid });
   q[QuestionSetIsFailed]();
 
-  await tc.handleAction(req, q);
+  await tc.handleAction(req.body.From, q);
 
   expect(twilioMessagesCreate).toBeCalledTimes(1);
   expect(twilioMessagesCreate).toBeCalledWith({
@@ -263,7 +263,7 @@ test(
     q[QuestionSetShouldSendInvalidRes]();
     q[ActionSetMessageSids] = setSids = jest.fn();
 
-    await tc.handleAction(req, q);
+    await tc.handleAction(req.body.From, q);
 
     expect(twilioMessagesCreate).toBeCalledTimes(2);
     expect(twilioMessagesCreate.mock.calls[0][0]).toEqual({
@@ -291,7 +291,7 @@ test('TwilioController handleAction receives Question that has not yet been answ
   twilioMessagesCreate.mockResolvedValueOnce({ sid });
   q[ActionSetMessageSids] = setSids = jest.fn();
 
-  await tc.handleAction(req, q);
+  await tc.handleAction(req.body.From, q);
 
   expect(twilioMessagesCreate).toBeCalledTimes(1);
   expect(twilioMessagesCreate).toBeCalledWith({
@@ -313,7 +313,7 @@ test('TwilioController handleAction receives Reply', async () => {
   twilioMessagesCreate.mockResolvedValueOnce({ sid });
   reply[ActionSetMessageSid] = jest.fn();
 
-  await tc.handleAction(req, reply);
+  await tc.handleAction(req.body.From, reply);
 
   expect(twilioMessagesCreate).toBeCalledTimes(1);
   expect(twilioMessagesCreate).toBeCalledWith({

--- a/tests/twilly.spec.ts
+++ b/tests/twilly.spec.ts
@@ -40,7 +40,7 @@ const getHandler = router => router.stack[1].route.stack[0].handle;
 const fcMock = {
   getCurrentFlow: jest.fn(),
   onInteractionEnd: null,
-  resolveActionFromState: jest.fn(),
+  resolveActionFromRequest: jest.fn(),
   resolveNextStateFromAction: jest.fn(),
 };
 const tcMock = {
@@ -90,7 +90,7 @@ function expectMockToBeCalledWith(fn: jest.Mock, n: number, args: any[][]) {
 function baseCaseTest(user = null) {
   expectMockToBeCalledWith(tcMock.getSmsCookieFromRequest, 1, [[reqMock]]);
   expectMockToBeCalledWith(
-    fcMock.resolveActionFromState,
+    fcMock.resolveActionFromRequest,
     2,
     [[reqMock, cookieMock, user],
      [reqMock, cookieMock, user]],
@@ -225,7 +225,7 @@ afterEach(() => {
 
   fcMock.onInteractionEnd = null;
   fcMock.getCurrentFlow.mockRestore();
-  fcMock.resolveActionFromState.mockRestore();
+  fcMock.resolveActionFromRequest.mockRestore();
   fcMock.resolveNextStateFromAction.mockRestore();
 
   tcMock.clearSmsCookie.mockRestore();
@@ -353,8 +353,8 @@ test('twilly handleIncomingWebhookRequest base case: 1 action', async () => {
   const router = twilly(defaultArgs);
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   await handleSmsWebhook(reqMock, resMock);
   baseCaseTest();
@@ -367,8 +367,8 @@ test('twilly handleIncomingWebhookRequest multiple actions', async () => {
   const actionMocks = [{}, {}, {}];
 
   actionMocks.forEach(
-    (mock: any) => fcMock.resolveActionFromState.mockResolvedValueOnce(mock));
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    (mock: any) => fcMock.resolveActionFromRequest.mockResolvedValueOnce(mock));
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   await handleSmsWebhook(reqMock, resMock);
 
@@ -376,7 +376,7 @@ test('twilly handleIncomingWebhookRequest multiple actions', async () => {
   expect(tcMock.getSmsCookieFromRequest).toBeCalledWith(reqMock);
 
   expectMockToBeCalledWith(
-    fcMock.resolveActionFromState,
+    fcMock.resolveActionFromRequest,
     4,
     [...Array(4)].map(() => [reqMock, cookieMock, null]),
   );
@@ -410,15 +410,15 @@ test('twilly handleIncomingWebhookRequest interaction completed', async () => {
   const handleSmsWebhook = getHandler(router);
 
   cookieMock.isComplete = true;
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
 
   await handleSmsWebhook(reqMock, resMock);
 
   expect(tcMock.getSmsCookieFromRequest).toBeCalledTimes(1);
   expect(tcMock.getSmsCookieFromRequest).toBeCalledWith(reqMock);
 
-  expect(fcMock.resolveActionFromState).toBeCalledTimes(1);
-  expect(fcMock.resolveActionFromState).toBeCalledWith(reqMock, cookieMock, null);
+  expect(fcMock.resolveActionFromRequest).toBeCalledTimes(1);
+  expect(fcMock.resolveActionFromRequest).toBeCalledWith(reqMock, cookieMock, null);
 
   expect(tcMock.sendMessageNotification).not.toBeCalled();
 
@@ -441,15 +441,15 @@ test('twilly handleIncomingWebhookRequest incomplete Question', async () => {
   const handleSmsWebhook = getHandler(router);
 
   actionMock = new Question(uniqueString());
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
 
   await handleSmsWebhook(reqMock, resMock);
 
   expect(tcMock.getSmsCookieFromRequest).toBeCalledTimes(1);
   expect(tcMock.getSmsCookieFromRequest).toBeCalledWith(reqMock);
 
-  expect(fcMock.resolveActionFromState).toBeCalledTimes(1);
-  expect(fcMock.resolveActionFromState).toBeCalledWith(reqMock, cookieMock, null);
+  expect(fcMock.resolveActionFromRequest).toBeCalledTimes(1);
+  expect(fcMock.resolveActionFromRequest).toBeCalledWith(reqMock, cookieMock, null);
 
   expect(tcMock.sendMessageNotification).not.toBeCalled();
 
@@ -473,7 +473,7 @@ test('twilly handleIncomingWebhookRequest answered Question', async () => {
 
   actionMock = new Question(uniqueString());
   actionMock[QuestionSetIsAnswered]();
-  fcMock.resolveActionFromState
+  fcMock.resolveActionFromRequest
     .mockResolvedValueOnce(actionMock)
     .mockResolvedValueOnce(null);
 
@@ -489,7 +489,7 @@ test('twilly handleIncomingWebhookRequest failed Question', async () => {
 
   actionMock = new Question(uniqueString());
   actionMock[QuestionSetIsFailed]();
-  fcMock.resolveActionFromState
+  fcMock.resolveActionFromRequest
     .mockResolvedValueOnce(actionMock)
     .mockResolvedValueOnce(null);
 
@@ -505,7 +505,7 @@ test('twilly handleIncomingWebhookRequest complete Question', async () => {
 
   actionMock = new Question(uniqueString());
   actionMock[QuestionSetIsFailed]();
-  fcMock.resolveActionFromState
+  fcMock.resolveActionFromRequest
     .mockResolvedValueOnce(actionMock)
     .mockResolvedValueOnce(null);
 
@@ -522,8 +522,8 @@ test('twilly getUserContext success case test', async () => {
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   await handleSmsWebhook(reqMock, resMock);
 
@@ -538,8 +538,8 @@ test('twilly onMessage hook success base case test', async () => {
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   await handleSmsWebhook(reqMock, resMock);
 
@@ -557,8 +557,8 @@ test('twilly onMessage hook success with getUserContext hook', async () => {
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   await handleSmsWebhook(reqMock, resMock);
 
@@ -578,14 +578,14 @@ test('twilly onMessage hook success returns a Message action', async () => {
   const msg = new Message(uniqueString(), uniqueString());
   onMessageMock.mockResolvedValue(msg);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   await handleSmsWebhook(reqMock, resMock);
 
   expectMockToBeCalledWith(tcMock.getSmsCookieFromRequest, 1, [[reqMock]]);
   expectMockToBeCalledWith(
-    fcMock.resolveActionFromState,
+    fcMock.resolveActionFromRequest,
     2,
     [[reqMock, cookieMock, null],
      [reqMock, cookieMock, null]],
@@ -609,7 +609,7 @@ test('twilly onInteractionEnd handler test success case', async () => {
 
   cookieMock.isComplete = true;
   fcMock.onInteractionEnd = onInteractionEndMock;
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
 
   await handleSmsWebhook(reqMock, resMock);
 
@@ -624,7 +624,7 @@ test('twilly onInteractionEnd handler test success case', async () => {
 
   cookieMock.isComplete = true;
   fcMock.onInteractionEnd = onInteractionEndMock;
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
 
   await handleSmsWebhook(reqMock, resMock);
 
@@ -642,7 +642,7 @@ test('twilly onInteractionEnd handler test with getUserContext success case', as
 
   cookieMock.isComplete = true;
   fcMock.onInteractionEnd = onInteractionEndMock;
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
 
   await handleSmsWebhook(reqMock, resMock);
 
@@ -660,7 +660,7 @@ test('twilly onInteractionEnd handler success case returns Message', async () =>
 
   cookieMock.isComplete = true;
   fcMock.onInteractionEnd = onInteractionEndMock;
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
 
   await handleSmsWebhook(reqMock, resMock);
 
@@ -680,7 +680,7 @@ test('twilly getUserContext throws error', async () => {
 
   getUserContextMock.mockRejectedValue(errorMock);
   await handleSmsWebhook(reqMock, resMock);
-  baseCaseErrorTest(fcMock.resolveActionFromState);
+  baseCaseErrorTest(fcMock.resolveActionFromRequest);
 });
 
 
@@ -694,7 +694,7 @@ test('twilly getUserContext throws error with onCatchError hook', async () => {
 
   getUserContextMock.mockRejectedValue(errorMock);
   await handleSmsWebhook(reqMock, resMock);
-  onCatchErrorTest(fcMock.resolveActionFromState);
+  onCatchErrorTest(fcMock.resolveActionFromRequest);
 });
 
 
@@ -710,7 +710,7 @@ test('twilly getUserContext throws error with onCatchError and onInteractionEnd 
   fcMock.onInteractionEnd = onInteractionEndMock;
 
   await handleSmsWebhook(reqMock, resMock);
-  onCatchErrorOnInteractionEndTest(fcMock.resolveActionFromState);
+  onCatchErrorOnInteractionEndTest(fcMock.resolveActionFromRequest);
 });
 
 
@@ -731,7 +731,7 @@ test(
     fcMock.onInteractionEnd = onInteractionEndMock;
 
     await handleSmsWebhook(reqMock, resMock);
-    onCatchErrorReturnsReplyTest(fcMock.resolveActionFromState, reply);
+    onCatchErrorReturnsReplyTest(fcMock.resolveActionFromRequest, reply);
   },
 );
 
@@ -752,7 +752,7 @@ test(
     onInteractionEndMock.mockRejectedValue(secondError);
 
     await handleSmsWebhook(reqMock, resMock);
-    onInteractionEndThrowsErrorTest(fcMock.resolveActionFromState, secondError);
+    onInteractionEndThrowsErrorTest(fcMock.resolveActionFromRequest, secondError);
   },
 );
 
@@ -775,55 +775,55 @@ test(
     fcMock.onInteractionEnd = onInteractionEndMock;
 
     await handleSmsWebhook(reqMock, resMock);
-    onCatchErrorReplyFailureTest(fcMock.resolveActionFromState, secondError);
+    onCatchErrorReplyFailureTest(fcMock.resolveActionFromRequest, secondError);
   },
 );
 
 
-test('twilly fc.resolveActionFromState throws error', async () => {
+test('twilly fc.resolveActionFromRequest throws error', async () => {
   const router = twilly(defaultArgs);
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+  fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
   await handleSmsWebhook(reqMock, resMock);
   baseCaseErrorTest(tcMock.handleAction);
 });
 
 
-test('twilly fc.resolveActionFromState throws error, onMessage hook', async () => {
+test('twilly fc.resolveActionFromRequest throws error, onMessage hook', async () => {
   const router = twilly({
     ...defaultArgs,
     onMessage: onMessageMock,
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+  fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
   await handleSmsWebhook(reqMock, resMock);
   baseCaseErrorTest(onMessageMock);
 });
 
 
-test('twilly fc.resolveActionFromState throws error with onCatchError hook', async () => {
+test('twilly fc.resolveActionFromRequest throws error with onCatchError hook', async () => {
   const router = twilly({
     ...defaultArgs,
     onCatchError: onCatchErrorMock,
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+  fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
   await handleSmsWebhook(reqMock, resMock);
   onCatchErrorTest(tcMock.handleAction);
 });
 
 
-test('twilly fc.resolveActionFromState throws error with onCatchError and onInteractionEnd hooks', async () => {
+test('twilly fc.resolveActionFromRequest throws error with onCatchError and onInteractionEnd hooks', async () => {
   const router = twilly({
     ...defaultArgs,
     onCatchError: onCatchErrorMock,
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+  fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
   fcMock.onInteractionEnd = onInteractionEndMock;
   await handleSmsWebhook(reqMock, resMock);
   onCatchErrorOnInteractionEndTest(tcMock.handleAction);
@@ -831,7 +831,7 @@ test('twilly fc.resolveActionFromState throws error with onCatchError and onInte
 
 
 test(
-  'twilly fc.resolveActionFromState throws error with onCatchError, onInteractionEnd, onMessage hooks',
+  'twilly fc.resolveActionFromRequest throws error with onCatchError, onInteractionEnd, onMessage hooks',
   async () => {
     const router = twilly({
       ...defaultArgs,
@@ -840,7 +840,7 @@ test(
     });
     const handleSmsWebhook = getHandler(router);
 
-    fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+    fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
     fcMock.onInteractionEnd = onInteractionEndMock;
     await handleSmsWebhook(reqMock, resMock);
     onCatchErrorOnInteractionEndTest(onMessageMock);
@@ -849,7 +849,7 @@ test(
 
 
 test(
-  'twilly fc.resolveActionFromState throws error with onInteractionEnd, if onCatchError returns Reply',
+  'twilly fc.resolveActionFromRequest throws error with onInteractionEnd, if onCatchError returns Reply',
   async () => {
     const router = twilly({
       ...defaultArgs,
@@ -861,7 +861,7 @@ test(
     onCatchErrorMock.mockReturnValue(reply);
     (<jest.Mock>updateContext).mockReturnValue(cookieMock);
     fcMock.onInteractionEnd = onInteractionEndMock;
-    fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+    fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
 
     await handleSmsWebhook(reqMock, resMock);
     onCatchErrorReturnsReplyTest(tcMock.handleAction, reply);
@@ -870,7 +870,7 @@ test(
 
 
 test(
-  'twilly fc.resolveActionFromState throws error with onInteractionEnd, if onCatchError returns Reply, onMessage hook',
+  'twilly fc.resolveActionFromRequest throws error with onInteractionEnd, if onCatchError returns Reply, onMessage hook',
   async () => {
     const router = twilly({
       ...defaultArgs,
@@ -883,7 +883,7 @@ test(
     onCatchErrorMock.mockReturnValue(reply);
     (<jest.Mock>updateContext).mockReturnValue(cookieMock);
     fcMock.onInteractionEnd = onInteractionEndMock;
-    fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+    fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
 
     await handleSmsWebhook(reqMock, resMock);
     onCatchErrorReturnsReplyTest(onMessageMock, reply);
@@ -892,7 +892,7 @@ test(
 
 
 test(
-  'twilly fc.resolveActionFromState throws error with onCatchError, onInteractionEnd throws Error',
+  'twilly fc.resolveActionFromRequest throws error with onCatchError, onInteractionEnd throws Error',
   async () => {
     const router = twilly({
       ...defaultArgs,
@@ -903,7 +903,7 @@ test(
 
     onInteractionEndMock.mockRejectedValue(secondError);
     fcMock.onInteractionEnd = onInteractionEndMock;
-    fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+    fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
 
     await handleSmsWebhook(reqMock, resMock);
     onInteractionEndThrowsErrorTest(tcMock.handleAction, secondError);
@@ -912,7 +912,7 @@ test(
 
 
 test(
-  'twilly fc.resolveActionFromState throws error with onCatchError, onInteractionEnd throws Error, onMessage hook',
+  'twilly fc.resolveActionFromRequest throws error with onCatchError, onInteractionEnd throws Error, onMessage hook',
   async () => {
     const router = twilly({
       ...defaultArgs,
@@ -924,7 +924,7 @@ test(
 
     onInteractionEndMock.mockRejectedValue(secondError);
     fcMock.onInteractionEnd = onInteractionEndMock;
-    fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+    fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
 
     await handleSmsWebhook(reqMock, resMock);
     onInteractionEndThrowsErrorTest(onMessageMock, secondError);
@@ -933,7 +933,7 @@ test(
 
 
 test(
-  'twilly fc.resolveActionFromState throws error, onCatchError returns Reply, TwilioController throws Error',
+  'twilly fc.resolveActionFromRequest throws error, onCatchError returns Reply, TwilioController throws Error',
   async () => {
     const router = twilly({
       ...defaultArgs,
@@ -945,7 +945,7 @@ test(
 
     onCatchErrorMock.mockReturnValue(reply);
     fcMock.onInteractionEnd = onInteractionEndMock;
-    fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+    fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
     tcMock.handleAction.mockRejectedValue(secondError);
 
     await handleSmsWebhook(reqMock, resMock);
@@ -955,7 +955,7 @@ test(
 
 
 test(
-  'twilly fc.resolveActionFromState throws error, onCatchError returns Reply, TwilioController throws Error',
+  'twilly fc.resolveActionFromRequest throws error, onCatchError returns Reply, TwilioController throws Error',
   async () => {
     const router = twilly({
       ...defaultArgs,
@@ -968,7 +968,7 @@ test(
 
     onCatchErrorMock.mockReturnValue(reply);
     fcMock.onInteractionEnd = onInteractionEndMock;
-    fcMock.resolveActionFromState.mockRejectedValue(errorMock);
+    fcMock.resolveActionFromRequest.mockRejectedValue(errorMock);
     tcMock.handleAction.mockRejectedValue(secondError);
 
     await handleSmsWebhook(reqMock, resMock);
@@ -985,8 +985,8 @@ test('twilly onMessage throws error', async () => {
   const handleSmsWebhook = getHandler(router);
 
   onMessageMock.mockRejectedValue(errorMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   await handleSmsWebhook(reqMock, resMock);
   baseCaseTest();
@@ -1002,8 +1002,8 @@ test('twilly onMessage throws error with onCatchError hook', async () => {
   const handleSmsWebhook = getHandler(router);
 
   onMessageMock.mockRejectedValue(errorMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   await handleSmsWebhook(reqMock, resMock);
   baseCaseTest();
@@ -1021,8 +1021,8 @@ test('twilly onMessage throws error with onCatchError and getUserContext hook', 
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   onMessageMock.mockRejectedValue(errorMock);
 
@@ -1041,18 +1041,18 @@ test('twilly onMessage hook: tc.sendMessageNotification throws error', async () 
   const handleSmsWebhook = getHandler(router);
   const msg = new Message(uniqueString(), uniqueString());
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   onMessageMock.mockResolvedValue(msg);
   tcMock.sendMessageNotification.mockRejectedValue(errorMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
 
   await handleSmsWebhook(reqMock, resMock);
 
   expectMockToBeCalledWith(tcMock.getSmsCookieFromRequest, 1, [[reqMock]]);
   expectMockToBeCalledWith(
-    fcMock.resolveActionFromState,
+    fcMock.resolveActionFromRequest,
     2,
     [[reqMock, cookieMock, null],
     [reqMock, cookieMock, null]],
@@ -1074,8 +1074,8 @@ test('twilly onMessage hook: tc.sendMessageNotification throws error with onCatc
   const handleSmsWebhook = getHandler(router);
   const msg = new Message(uniqueString(), uniqueString());
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   onMessageMock.mockResolvedValue(msg);
   tcMock.sendMessageNotification.mockRejectedValue(errorMock);
@@ -1084,7 +1084,7 @@ test('twilly onMessage hook: tc.sendMessageNotification throws error with onCatc
 
   expectMockToBeCalledWith(tcMock.getSmsCookieFromRequest, 1, [[reqMock]]);
   expectMockToBeCalledWith(
-    fcMock.resolveActionFromState,
+    fcMock.resolveActionFromRequest,
     2,
     [[reqMock, cookieMock, null],
     [reqMock, cookieMock, null]],
@@ -1113,14 +1113,14 @@ test(
 
     onMessageMock.mockResolvedValue(msg);
     tcMock.sendMessageNotification.mockRejectedValue(errorMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     await handleSmsWebhook(reqMock, resMock);
 
     expectMockToBeCalledWith(tcMock.getSmsCookieFromRequest, 1, [[reqMock]]);
     expectMockToBeCalledWith(
-      fcMock.resolveActionFromState,
+      fcMock.resolveActionFromRequest,
       2,
       [[reqMock, cookieMock, userMock],
         [reqMock, cookieMock, userMock]],
@@ -1140,8 +1140,8 @@ test('twilly tc.handleAction throws error', async () => {
   const router = twilly(defaultArgs);
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   tcMock.handleAction.mockRejectedValue(errorMock);
   await handleSmsWebhook(reqMock, resMock);
@@ -1156,8 +1156,8 @@ test('twilly tc.handleAction throws error with onCatchError hook', async () => {
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   tcMock.handleAction.mockRejectedValue(errorMock);
   await handleSmsWebhook(reqMock, resMock);
@@ -1172,8 +1172,8 @@ test('twilly tc.handleAction throws error with onCatchError and onInteractionEnd
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   tcMock.handleAction.mockRejectedValue(errorMock);
   fcMock.onInteractionEnd = onInteractionEndMock;
@@ -1192,8 +1192,8 @@ test(
     const handleSmsWebhook = getHandler(router);
     const reply = new Reply(uniqueString());
 
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     onCatchErrorMock.mockReturnValue(reply);
     (<jest.Mock>updateContext).mockReturnValue(cookieMock);
@@ -1218,8 +1218,8 @@ test(
     const handleSmsWebhook = getHandler(router);
     const secondError = new Error(uniqueString());
 
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     fcMock.onInteractionEnd = onInteractionEndMock;
     tcMock.handleAction.mockRejectedValue(errorMock);
@@ -1242,8 +1242,8 @@ test(
     const secondError = new Error(uniqueString());
     const reply = new Reply(uniqueString());
 
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     onCatchErrorMock.mockReturnValue(reply);
     fcMock.onInteractionEnd = onInteractionEndMock;
@@ -1261,8 +1261,8 @@ test('twilly fc.resolveNextStateFromAction throws error', async () => {
   const router = twilly(defaultArgs);
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   fcMock.resolveNextStateFromAction.mockRejectedValue(errorMock);
   await handleSmsWebhook(reqMock, resMock);
@@ -1277,8 +1277,8 @@ test('twilly fc.resolveNextStateFromAction throws error with onCatchError hook',
   });
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   fcMock.resolveNextStateFromAction.mockRejectedValue(errorMock);
   await handleSmsWebhook(reqMock, resMock);
@@ -1295,8 +1295,8 @@ test(
     });
     const handleSmsWebhook = getHandler(router);
 
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     fcMock.resolveNextStateFromAction.mockRejectedValue(errorMock);
     fcMock.onInteractionEnd = onInteractionEndMock;
@@ -1317,8 +1317,8 @@ test(
     const handleSmsWebhook = getHandler(router);
     const reply = new Reply(uniqueString());
 
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     onCatchErrorMock.mockReturnValue(reply);
     (<jest.Mock>updateContext).mockReturnValue(cookieMock);
@@ -1342,8 +1342,8 @@ test(
     const handleSmsWebhook = getHandler(router);
     const secondError = new Error(uniqueString());
 
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     onInteractionEndMock.mockRejectedValue(secondError);
     fcMock.onInteractionEnd = onInteractionEndMock;
@@ -1368,8 +1368,8 @@ test(
     const secondError = new Error(uniqueString());
     const reply = new Reply(uniqueString());
 
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     onCatchErrorMock.mockReturnValue(reply);
     fcMock.onInteractionEnd = onInteractionEndMock;
@@ -1388,8 +1388,8 @@ test('twilly fc.onInteractionEnd in main block throws error', async () => {
   const router = twilly(defaultArgs);
   const handleSmsWebhook = getHandler(router);
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   cookieMock.isComplete = true;
   fcMock.onInteractionEnd = onInteractionEndMock;
@@ -1409,8 +1409,8 @@ test(
     });
     const handleSmsWebhook = getHandler(router);
 
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     cookieMock.isComplete = true;
     fcMock.onInteractionEnd = onInteractionEndMock;
@@ -1429,8 +1429,8 @@ test('twilly tc.sendMessageNotification in main block throws error', async () =>
   const handleSmsWebhook = getHandler(router);
   const msg = new Message(uniqueString(), uniqueString());
 
-  fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-  fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+  fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
   cookieMock.isComplete = true;
   fcMock.onInteractionEnd = onInteractionEndMock;
@@ -1452,8 +1452,8 @@ test(
     const handleSmsWebhook = getHandler(router);
     const msg = new Message(uniqueString(), uniqueString());
 
-    fcMock.resolveActionFromState.mockResolvedValueOnce(actionMock);
-    fcMock.resolveActionFromState.mockResolvedValueOnce(null);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(actionMock);
+    fcMock.resolveActionFromRequest.mockResolvedValueOnce(null);
 
     cookieMock.isComplete = true;
     fcMock.onInteractionEnd = onInteractionEndMock;

--- a/tests/twilly.spec.ts
+++ b/tests/twilly.spec.ts
@@ -1,11 +1,9 @@
 import { uniqueString, randomFlow, getSha256Hash } from '../src/util';
 import {
-  Flow,
   FlowSchema,
   Message,
   Question,
   Reply,
-  Trigger,
   twilly,
 } from '../src'; // tests should fail if not all objects in build are exported
 import {

--- a/tests/twilly.spec.ts
+++ b/tests/twilly.spec.ts
@@ -96,7 +96,7 @@ function baseCaseTest(user = null) {
      [reqMock, cookieMock, user]],
   );
   expect(tcMock.sendMessageNotification).not.toBeCalled();
-  expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock, actionMock]]);
+  expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
   expectMockToBeCalledWith(
     fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
   expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);
@@ -140,7 +140,9 @@ function onCatchErrorReturnsReplyTest(
   expectMockToBeCalledWith(
     tcMock.handleAction,
     tcHandleActionCalled ? 2 : 1, // true implies we are testing tcMock.handleAction
-    tcHandleActionCalled ? [[reqMock, actionMock], [reqMock, reply]] : [[reqMock, reply]],
+    tcHandleActionCalled ?
+      [[reqMock.body.From, actionMock], [reqMock.body.From, reply]] :
+      [[reqMock.body.From, reply]],
   );
   expectMockToBeCalledWith(
     fcMock.onInteractionEnd, 1, [[cookieMock.interactionContext, null]]);
@@ -387,7 +389,7 @@ test('twilly handleIncomingWebhookRequest multiple actions', async () => {
     tcMock.handleAction,
     3,
     actionMocks.map(
-      (mock: any) => [reqMock, mock]),
+      (mock: any) => [reqMock.body.From, mock]),
   );
 
   expectMockToBeCalledWith(
@@ -423,7 +425,7 @@ test('twilly handleIncomingWebhookRequest interaction completed', async () => {
   expect(tcMock.sendMessageNotification).not.toBeCalled();
 
   expect(tcMock.handleAction).toBeCalledTimes(1);
-  expect(tcMock.handleAction).toBeCalledWith(reqMock, actionMock);
+  expect(tcMock.handleAction).toBeCalledWith(reqMock.body.From, actionMock);
 
   expect(fcMock.resolveNextStateFromAction).toBeCalledTimes(1);
   expect(fcMock.resolveNextStateFromAction).toBeCalledWith(reqMock, cookieMock, actionMock);
@@ -454,7 +456,7 @@ test('twilly handleIncomingWebhookRequest incomplete Question', async () => {
   expect(tcMock.sendMessageNotification).not.toBeCalled();
 
   expect(tcMock.handleAction).toBeCalledTimes(1);
-  expect(tcMock.handleAction).toBeCalledWith(reqMock, actionMock);
+  expect(tcMock.handleAction).toBeCalledWith(reqMock.body.From, actionMock);
 
   expect(fcMock.resolveNextStateFromAction).toBeCalledTimes(1);
   expect(fcMock.resolveNextStateFromAction).toBeCalledWith(reqMock, cookieMock, actionMock);
@@ -592,7 +594,7 @@ test('twilly onMessage hook success returns a Message action', async () => {
   );
   expectMockToBeCalledWith(
     tcMock.sendMessageNotification, 1, [[msg]]);
-  expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock, actionMock]]);
+  expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
   expectMockToBeCalledWith(
     fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
   expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);
@@ -1057,7 +1059,7 @@ test('twilly onMessage hook: tc.sendMessageNotification throws error', async () 
     [[reqMock, cookieMock, null],
     [reqMock, cookieMock, null]],
   );
-  expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock, actionMock]]);
+  expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
   expectMockToBeCalledWith(
     fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
   expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);
@@ -1089,7 +1091,7 @@ test('twilly onMessage hook: tc.sendMessageNotification throws error with onCatc
     [[reqMock, cookieMock, null],
     [reqMock, cookieMock, null]],
   );
-  expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock, actionMock]]);
+  expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
   expectMockToBeCalledWith(
     fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
   expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);
@@ -1125,7 +1127,7 @@ test(
       [[reqMock, cookieMock, userMock],
         [reqMock, cookieMock, userMock]],
     );
-    expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock, actionMock]]);
+    expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
     expectMockToBeCalledWith(
       fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
     expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);

--- a/tests/twilly.spec.ts
+++ b/tests/twilly.spec.ts
@@ -98,7 +98,7 @@ function baseCaseTest(user = null) {
   expect(tcMock.sendMessageNotification).not.toBeCalled();
   expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
   expectMockToBeCalledWith(
-    fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
+    fcMock.resolveNextStateFromAction, 1, [[reqMock.body.Body, cookieMock, actionMock]]);
   expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);
   expectMockToBeCalledWith(tcMock.sendEmptyResponse, 1, [[resMock]]);
 }
@@ -396,7 +396,7 @@ test('twilly handleIncomingWebhookRequest multiple actions', async () => {
     fcMock.resolveNextStateFromAction,
     3,
     actionMocks.map(
-      (mock: any) => [reqMock, cookieMock, mock]),
+      (mock: any) => [reqMock.body.Body, cookieMock, mock]),
   );
 
   expect(tcMock.setSmsCookie).toBeCalledTimes(1);
@@ -428,7 +428,7 @@ test('twilly handleIncomingWebhookRequest interaction completed', async () => {
   expect(tcMock.handleAction).toBeCalledWith(reqMock.body.From, actionMock);
 
   expect(fcMock.resolveNextStateFromAction).toBeCalledTimes(1);
-  expect(fcMock.resolveNextStateFromAction).toBeCalledWith(reqMock, cookieMock, actionMock);
+  expect(fcMock.resolveNextStateFromAction).toBeCalledWith(reqMock.body.Body, cookieMock, actionMock);
 
   expect(tcMock.clearSmsCookie).toBeCalledTimes(1);
   expect(tcMock.clearSmsCookie).toBeCalledWith(resMock);
@@ -459,7 +459,7 @@ test('twilly handleIncomingWebhookRequest incomplete Question', async () => {
   expect(tcMock.handleAction).toBeCalledWith(reqMock.body.From, actionMock);
 
   expect(fcMock.resolveNextStateFromAction).toBeCalledTimes(1);
-  expect(fcMock.resolveNextStateFromAction).toBeCalledWith(reqMock, cookieMock, actionMock);
+  expect(fcMock.resolveNextStateFromAction).toBeCalledWith(reqMock.body.Body, cookieMock, actionMock);
 
   expect(tcMock.setSmsCookie).toBeCalledTimes(1);
   expect(tcMock.setSmsCookie).toBeCalledWith(resMock, cookieMock);
@@ -596,7 +596,7 @@ test('twilly onMessage hook success returns a Message action', async () => {
     tcMock.sendMessageNotification, 1, [[msg]]);
   expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
   expectMockToBeCalledWith(
-    fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
+    fcMock.resolveNextStateFromAction, 1, [[reqMock.body.Body, cookieMock, actionMock]]);
   expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);
   expectMockToBeCalledWith(tcMock.sendEmptyResponse, 1, [[resMock]]);
 });
@@ -1061,7 +1061,7 @@ test('twilly onMessage hook: tc.sendMessageNotification throws error', async () 
   );
   expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
   expectMockToBeCalledWith(
-    fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
+    fcMock.resolveNextStateFromAction, 1, [[reqMock.body.Body, cookieMock, actionMock]]);
   expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);
   expectMockToBeCalledWith(tcMock.sendEmptyResponse, 1, [[resMock]]);
 });
@@ -1093,7 +1093,7 @@ test('twilly onMessage hook: tc.sendMessageNotification throws error with onCatc
   );
   expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
   expectMockToBeCalledWith(
-    fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
+    fcMock.resolveNextStateFromAction, 1, [[reqMock.body.Body, cookieMock, actionMock]]);
   expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);
   expectMockToBeCalledWith(tcMock.sendEmptyResponse, 1, [[resMock]]);
   expectMockToBeCalledWith(
@@ -1129,7 +1129,7 @@ test(
     );
     expectMockToBeCalledWith(tcMock.handleAction, 1, [[reqMock.body.From, actionMock]]);
     expectMockToBeCalledWith(
-      fcMock.resolveNextStateFromAction, 1, [[reqMock, cookieMock, actionMock]]);
+      fcMock.resolveNextStateFromAction, 1, [[reqMock.body.Body, cookieMock, actionMock]]);
     expectMockToBeCalledWith(tcMock.setSmsCookie, 1, [[resMock, cookieMock]]);
     expectMockToBeCalledWith(tcMock.sendEmptyResponse, 1, [[resMock]]);
     expectMockToBeCalledWith(


### PR DESCRIPTION
Add `triggerFlow` to the exported interface of the library.

Usage:

```javascript
const { Flow, Reply, triggerFlow } = require('./twilly');
const app = require('express')();

// App setup...

// Example request, accepts a POST request with a JSON body with a single field:
// "toNumber", a string field with the phone number you wish to send a message
// to.
app.post('/message', (req, res) => {
	const toNumber = req.body.toNumber;
	triggerFlow(
		toNumber,
		new Flow('messageUser').addAction('reply', new Reply('Hello world!')),
	);
	res.status(200).end();
});

// Rest of app...

```

### Still needs unit tests before ready for release
